### PR TITLE
Updated the import for keyboard component

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -1,8 +1,9 @@
 /* @flow */
 
 import { PropTypes } from 'react'
-import ReactNative, { TextInput, Keyboard } from 'react-native'
+import ReactNative, { TextInput } from 'react-native'
 import TimerMixin from 'react-timer-mixin'
+import Keyboard from 'Keyboard'
 
 const _KAM_DEFAULT_TAB_BAR_HEIGHT = 49
 const _KAM_KEYBOARD_OPENING_TIME = 250


### PR DESCRIPTION
This link says that Keyboard should be imported from 'Keyboard' instead of 'react-native' https://github.com/facebook/react-native/issues/2819#issuecomment-224307128