### PR TITLE
[BUG] If "viewIsInsideTabBar" is false, set keyboardSpace set as 0

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -24,7 +24,7 @@ const KeyboardAwareMixin = {
 
   setViewIsInsideTabBar: function (viewIsInsideTabBar: bool) {
     this.viewIsInsideTabBar = viewIsInsideTabBar
-    this.setState({keyboardSpace: _KAM_DEFAULT_TAB_BAR_HEIGHT})
+    this.setState({keyboardSpace: this.viewIsInsideTabBar ? _KAM_DEFAULT_TAB_BAR_HEIGHT : 0})
   },
 
   setResetScrollToCoords: function (coords: {x: number, y: number}) {


### PR DESCRIPTION
Even though "viewIsInsideTabBar" value is false, "ScrollView" has marine as tab-bar on the bottom.
Set "keyboardSpace" as 0 if "viewIsInsideTabBar" prop is {false}
It's fine after focused once. so, this commit fixed bottom margin when it's rendered first place.  