### PR TITLE
Feat(Restore Position): Change default reset action

### DIFF
--- a/lib/KeyboardAwareListView.js
+++ b/lib/KeyboardAwareListView.js
@@ -20,10 +20,6 @@ const KeyboardAwareListView = React.createClass({
     this.setResetScrollToCoords(this.props.resetScrollToCoords)
   },
 
-  getScrollResponder() {
-    return this.refs._rnkasv_keyboardView.getScrollResponder()
-  },
-
   render: function () {
     return (
       <ListView

--- a/lib/KeyboardAwareListView.js
+++ b/lib/KeyboardAwareListView.js
@@ -20,6 +20,10 @@ const KeyboardAwareListView = React.createClass({
     this.setResetScrollToCoords(this.props.resetScrollToCoords)
   },
 
+  getScrollResponder() {
+    return this.refs._rnkasv_keyboardView.getScrollResponder()
+  },
+
   render: function () {
     return (
       <ListView
@@ -28,6 +32,10 @@ const KeyboardAwareListView = React.createClass({
         contentInset={{bottom: this.state.keyboardSpace}}
         showsVerticalScrollIndicator={true}
         {...this.props}
+        onScroll={e => {
+          this.handleOnScroll(e)
+          this.props.onScroll && this.props.onScroll(e)
+        }}
       />
     )
   },

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -58,6 +58,10 @@ const KeyboardAwareMixin = {
 
       }
     }
+
+    if (!this.resetCoords) {
+      this.defaultResetScrollToCoords = this.position
+    }
   },
 
   resetKeyboardSpace: function () {
@@ -68,6 +72,8 @@ const KeyboardAwareMixin = {
     // Reset scroll position after keyboard dismissal
     if (this.resetCoords) {
       this.scrollToPosition(this.resetCoords.x, this.resetCoords.y, true)
+    } else {
+      this.scrollToPosition(this.defaultResetScrollToCoords.x, this.defaultResetScrollToCoords.y, true)
     }
   },
 
@@ -102,6 +108,14 @@ const KeyboardAwareMixin = {
   scrollToFocusedInputWithNodeHandle: function (nodeID: number, extraHeight: number = this.props.extraHeight) {
     const reactNode = ReactNative.findNodeHandle(nodeID)
     this.scrollToFocusedInput(reactNode, extraHeight)
+  },
+
+  position: {x: 0, y: 0},
+
+  defaultResetScrollToCoords: {x: 0, y: 0},
+
+  handleOnScroll: function (e) {
+    this.position = e.nativeEvent.contentOffset
   },
 }
 

--- a/lib/KeyboardAwareScrollView.js
+++ b/lib/KeyboardAwareScrollView.js
@@ -27,7 +27,12 @@ const KeyboardAwareScrollView = React.createClass({
         keyboardDismissMode='interactive'
         contentInset={{bottom: this.state.keyboardSpace}}
         showsVerticalScrollIndicator={true}
-        {...this.props}>
+        {...this.props}
+        onScroll={e => {
+          this.handleOnScroll(e)
+          this.props.onScroll && this.props.onScroll(e)
+        }}
+        >
         {this.props.children}
       </ScrollView>
     )


### PR DESCRIPTION
Change default action, restore scroll position after keyboard hides if `resetScrollToCoords` is not set.

![restore_position](https://cloud.githubusercontent.com/assets/12252463/17585008/042c788c-5fec-11e6-850a-aae8d3516680.gif)

