### PR TITLE
Fix example code relating to v0.0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ As of `v0.1.0`, the component auto scrolls to the focused `TextInput` 😎. For 
 In order to scroll to any `TextInput` field, you can use the built-in method `scrollToFocusedInput`. Example:
 
 ```js
-_scrollToInput (reactNode: any) {
+_scrollToInput (event, reactNode: any) {
   // Add a 'scroll' ref to your ScrollView
-  this.refs.scroll.scrollToFocusedInput(reactNode)
+  this.refs.scroll.scrollToFocusedInput(event, reactNode)
 }
 ```
 
@@ -59,7 +59,7 @@ _scrollToInput (reactNode: any) {
   <View>
     <TextInput onFocus={(event: Event) => {
       // `bind` the function if you're using ES6 classes
-      this._scrollToInput(ReactNative.findNodeHandle(event.target))
+      this._scrollToInput(event, ReactNative.findNodeHandle(event.target))
     }/>
   </View>
 </KeyboardAwareScrollView>


### PR DESCRIPTION
👋 

I've been trying to get the example code working with `0.0.7` as I'm currently stuck on a lower version of React Native and have been going around in circles as to why it wasn't working.

After resorting to checking the source code, `scrollToFocusedInput` takes the node as the 2nd argument, not the first as per the `README.md`. I know it's only minor, but it may save someone else a little time in the future if they also can't be on the later versions of RN.

Code for reference from `0.0.7`.

``` js
scrollToFocusedInput: function (event: Object, reactNode: Object, extraHeight: number = _KAM_DEFAULT_TAB_BAR_HEIGHT)
```
