### PR TITLE
Only scroll to input when hidden by the keyboard

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -52,12 +52,18 @@ const KeyboardAwareMixin = {
       if (!currentlyFocusedField) {
         return
       }
+
       UIManager.viewIsDescendantOf(
         currentlyFocusedField,
         this.getScrollResponder().getInnerViewNode(),
         (isAncestor) => {
           if (isAncestor) {
-            this.scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
+            // Check if the TextInput will be hidden by the keyboard
+            UIManager.measureInWindow(currentlyFocusedField, (x, y, width, height) => {
+              if (y + height > frames.endCoordinates.screenY) {
+                this.scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
+              }
+            })
           }
         }
       )


### PR DESCRIPTION
Measure where the input is in the screen and check if it will be hidden by the keyboard before scrolling to it.

This makes scrolling a lot less aggressive and match behaviour of apple apps.

Related issue: #39