### PR TITLE
[BUG] Do Not to set keyboardSpace when view is NOT inside tab bar

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -26,7 +26,9 @@ const KeyboardAwareMixin = {
 
   setViewIsInsideTabBar: function (viewIsInsideTabBar: bool) {
     this.viewIsInsideTabBar = viewIsInsideTabBar
-    this.setState({keyboardSpace: _KAM_DEFAULT_TAB_BAR_HEIGHT})
+    if (viewIsInsideTabBar) {
+        this.setState({keyboardSpace: _KAM_DEFAULT_TAB_BAR_HEIGHT})
+    }
   },
 
   setResetScrollToCoords: function (coords: {x: number, y: number}) {

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -78,7 +78,7 @@ const KeyboardAwareMixin = {
   },
 
   resetKeyboardSpace: function () {
-    const keyboardSpace: number = (this.props.viewIsInsideTabBar) ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight : this.props.extraScrollHeight
+    const keyboardSpace: number = (this.props.viewIsInsideTabBar) ? _KAM_DEFAULT_TAB_BAR_HEIGHT : 0 
     this.setState({keyboardSpace})
     // Reset scroll position after keyboard dismissal
     if (this.resetCoords) {


### PR DESCRIPTION
keyboardSpace will always be set to `49` no matter what `viewIsInsideTabBar` is.
It will add a useless bottom padding to the ScrollView that isn't under a tab bar.

Please check it out. Thanks.