### PR TITLE
Make sure `this.keyboardWill(Show|Hide)Event` exists

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -93,8 +93,8 @@ const KeyboardAwareMixin = {
   },
 
   componentWillUnmount: function () {
-    this.keyboardWillShowEvent.remove()
-    this.keyboardWillHideEvent.remove()
+    this.keyboardWillShowEvent && this.keyboardWillShowEvent.remove()
+    this.keyboardWillHideEvent && this.keyboardWillHideEvent.remove()
   },
 
   scrollToPosition: function (x: number, y: number, animated: bool = false) {


### PR DESCRIPTION
It can be undefined thus causing app crashes.

Here's a screenshot from the crash report in fabric:

![screen shot 2016-11-16 at 10 44 40](https://cloud.githubusercontent.com/assets/410305/20342783/13d35bb0-abec-11e6-8649-ffba9cda8039.png)
