### PR TITLE
Fix #86 unnecessary space in the bottom

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -26,7 +26,10 @@ const KeyboardAwareMixin = {
 
   setViewIsInsideTabBar: function (viewIsInsideTabBar: bool) {
     this.viewIsInsideTabBar = viewIsInsideTabBar
-    this.setState({keyboardSpace: _KAM_DEFAULT_TAB_BAR_HEIGHT})
+    const keyboardSpace = viewIsInsideTabBar ? _KAM_DEFAULT_TAB_BAR_HEIGHT : 0
+    if (this.state.keyboardSpace !== keyboardSpace) {
+      this.setState({keyboardSpace})
+    }
   },
 
   setResetScrollToCoords: function (coords: {x: number, y: number}) {


### PR DESCRIPTION
Make `{keyboardSpace: _KAM_DEFAULT_TAB_BAR_HEIGHT}` in `KeyboardAwareMixin.setViewIsInsideTabBar`conditional to argument `viewIsInsideTabBar`.

This removes the unnecessary bottom spaces when `props. viewIsInsideTabBar` is not set to true.

Fixes issue #86 .