### PR TITLE
Fix flow errors

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -4,6 +4,8 @@ import { PropTypes } from 'react'
 import ReactNative, { TextInput, Keyboard, UIManager } from 'react-native'
 import TimerMixin from 'react-timer-mixin'
 
+import type { Event } from 'react-native'
+
 const _KAM_DEFAULT_TAB_BAR_HEIGHT: number = 49
 const _KAM_KEYBOARD_OPENING_TIME: number = 250
 const _KAM_EXTRA_HEIGHT: number = 75
@@ -112,7 +114,11 @@ const KeyboardAwareMixin = {
   /**
    * @param extraHeight: takes an extra height in consideration.
    */
-  scrollToFocusedInput: function (reactNode: Object, extraHeight: number = this.props.extraHeight) {
+  scrollToFocusedInput: function (reactNode: Object, extraHeight: number) {
+    if (extraHeight === undefined) {
+        extraHeight = this.props.extraHeight;
+    }
+
     const scrollView = this.refs._rnkasv_keyboardView.getScrollResponder()
     this.setTimeout(() => {
       scrollView.scrollResponderScrollNativeHandleToKeyboard(
@@ -121,7 +127,11 @@ const KeyboardAwareMixin = {
     }, _KAM_KEYBOARD_OPENING_TIME)
   },
 
-  scrollToFocusedInputWithNodeHandle: function (nodeID: number, extraHeight: number = this.props.extraHeight) {
+  scrollToFocusedInputWithNodeHandle: function (nodeID: number, extraHeight: number) {
+    if (extraHeight === undefined) {
+        extraHeight = this.props.extraHeight;
+    }
+
     const reactNode = ReactNative.findNodeHandle(nodeID)
     this.scrollToFocusedInput(reactNode, extraHeight + this.props.extraScrollHeight)
   },
@@ -130,7 +140,7 @@ const KeyboardAwareMixin = {
 
   defaultResetScrollToCoords: {x: 0, y: 0},
 
-  handleOnScroll: function (e) {
+  handleOnScroll: function (e: Event) {
     this.position = e.nativeEvent.contentOffset
   },
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint lib",
-    "test": "npm run lint"
+    "test": "npm run lint",
+    "flow": "flow check"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,7 @@
   "devDependencies": {
     "babel-eslint": "^6.0.4",
     "eslint": "^3.17.1",
-    "eslint-plugin-react": "^6.10.0"
+    "eslint-plugin-react": "^6.10.0",
+    "flow-bin": "0.33.0"
   }
 }


### PR DESCRIPTION
Had to refactor the default argument as flow has trouble understanding what `this` would be at that point in time. (https://github.com/facebook/flow/issues/1234)
The flow check currently fails as react-native isn't installed in dev, but passes if you install react-native. I wasn't sure if I should add it to the devDependencies or not