### PR TITLE
Fix issue #104

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -76,7 +76,9 @@ const KeyboardAwareMixin = {
       )
     }
     if (!this.resetCoords) {
-      this.defaultResetScrollToCoords = this.position
+      if (!this.defaultResetScrollToCoords) {
+        this.defaultResetScrollToCoords = this.position
+      }
     }
   },
 
@@ -89,7 +91,11 @@ const KeyboardAwareMixin = {
     } else if (this.resetCoords) {
       this.scrollToPosition(this.resetCoords.x, this.resetCoords.y, true)
     } else {
-      this.scrollToPosition(this.defaultResetScrollToCoords.x, this.defaultResetScrollToCoords.y, true)
+      if (this.defaultResetScrollToCoords) {
+        this.scrollToPosition(this.defaultResetScrollToCoords.x, this.defaultResetScrollToCoords.y, true)
+      } else {
+        this.scrollToPosition(0, 0, true)
+      }
     }
   },
 
@@ -128,7 +134,7 @@ const KeyboardAwareMixin = {
 
   position: {x: 0, y: 0},
 
-  defaultResetScrollToCoords: {x: 0, y: 0},
+  defaultResetScrollToCoords: null, // format: {x: 0, y: 0}
 
   handleOnScroll: function (e) {
     this.position = e.nativeEvent.contentOffset

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -87,12 +87,14 @@ const KeyboardAwareMixin = {
     this.setState({keyboardSpace})
     // Reset scroll position after keyboard dismissal
     if (this.props.enableResetScrollToCoords === false) {
+      this.defaultResetScrollToCoords = null
       return
     } else if (this.resetCoords) {
       this.scrollToPosition(this.resetCoords.x, this.resetCoords.y, true)
     } else {
       if (this.defaultResetScrollToCoords) {
         this.scrollToPosition(this.defaultResetScrollToCoords.x, this.defaultResetScrollToCoords.y, true)
+        this.defaultResetScrollToCoords = null
       } else {
         this.scrollToPosition(0, 0, true)
       }


### PR DESCRIPTION
Fix issue #104.

The root cause is that the `Minxin` save the current position when the keyboard is showed every time. So if the keyboard is showed already, `Minxin` will save the wrong position. So I make it only save the position at the first time.