### PR TITLE
Advanced 103

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ All the `ScrollView`/`ListView` props will be passed.
 | `extraScrollHeight` | `number` | Adds an extra offset to the keyboard. Useful if you want to stick elements above the keyboard. |
 | `enableResetScrollToCoords` | `boolean` | Lets the user enable or disable automatic resetScrollToCoords. |
 
+### Methods
+
+| **Method** | **Parameter** | **Description** |
+|------------|---------------|-----------------|
+| `getScrollResponder` | `void` | Get `ScrollResponder` |
+| `scrollToPosition` | `x: number, y: number, animated: bool = true` | Scroll to specific position with or without animation. |
+| `scrollToEnd` | `animated?: bool = true` | Scroll to end with or without animation. |
+
 ## License
 
 MIT.

--- a/lib/KeyboardAwareListView.js
+++ b/lib/KeyboardAwareListView.js
@@ -19,10 +19,6 @@ const KeyboardAwareListView = React.createClass({
     this.setResetScrollToCoords(this.props.resetScrollToCoords)
   },
 
-  getScrollResponder() {
-    return this.refs._rnkasv_keyboardView.getScrollResponder()
-  },
-
   render: function () {
     return (
       <ListView

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -104,23 +104,24 @@ const KeyboardAwareMixin = {
     this.keyboardWillHideEvent && this.keyboardWillHideEvent.remove()
   },
 
+  getScrollResponder() {
+    return this.refs._rnkasv_keyboardView.getScrollResponder()
+  },
+
   scrollToPosition: function (x: number, y: number, animated: bool = false) {
-    const scrollView = this.refs._rnkasv_keyboardView.getScrollResponder()
-    scrollView.scrollResponderScrollTo({x: x, y: y, animated: animated})
+    this.getScrollResponder().scrollResponderScrollTo({x: x, y: y, animated: animated})
   },
 
   scrollToEnd: function (animated?: boolean) {
-    const scrollView = this.refs._rnkasv_keyboardView.getScrollResponder()
-    scrollView.scrollResponderScrollToEnd({animated: animated})
+    this.getScrollResponder().scrollResponderScrollToEnd({animated: animated})
   },
 
   /**
    * @param extraHeight: takes an extra height in consideration.
    */
   scrollToFocusedInput: function (reactNode: Object, extraHeight: number = this.props.extraHeight) {
-    const scrollView = this.refs._rnkasv_keyboardView.getScrollResponder()
     this.setTimeout(() => {
-      scrollView.scrollResponderScrollNativeHandleToKeyboard(
+      this.getScrollResponder().scrollResponderScrollNativeHandleToKeyboard(
         reactNode, extraHeight, true
       )
     }, _KAM_KEYBOARD_OPENING_TIME)

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -109,6 +109,11 @@ const KeyboardAwareMixin = {
     scrollView.scrollResponderScrollTo({x: x, y: y, animated: animated})
   },
 
+  scrollToEnd: function (animated?: boolean) {
+    const scrollView = this.refs._rnkasv_keyboardView.getScrollResponder()
+    scrollView.scrollResponderScrollToEnd({animated: animated})
+  },
+
   /**
    * @param extraHeight: takes an extra height in consideration.
    */

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -108,11 +108,11 @@ const KeyboardAwareMixin = {
     return this.refs._rnkasv_keyboardView.getScrollResponder()
   },
 
-  scrollToPosition: function (x: number, y: number, animated: bool = false) {
+  scrollToPosition: function (x: number, y: number, animated: bool = true) {
     this.getScrollResponder().scrollResponderScrollTo({x: x, y: y, animated: animated})
   },
 
-  scrollToEnd: function (animated?: boolean) {
+  scrollToEnd: function (animated?: bool = true) {
     this.getScrollResponder().scrollResponderScrollToEnd({animated: animated})
   },
 

--- a/lib/KeyboardAwareScrollView.js
+++ b/lib/KeyboardAwareScrollView.js
@@ -20,10 +20,6 @@ const KeyboardAwareScrollView = React.createClass({
     this.setResetScrollToCoords(this.props.resetScrollToCoords)
   },
 
-  getScrollResponder() {
-    return this.refs._rnkasv_keyboardView.getScrollResponder()
-  },
-
   render: function () {
     return (
       <ScrollView


### PR DESCRIPTION
According to #103 , This PR contains:

- Add `scrollToEnd`
- Update doc
- Refactor `getScrollResponder`

@alvaromb I didn't add `scrollWithoutAnimationTo` since it's [deprecated](https://github.com/facebook/react-native/blob/master/Libraries/Components/ScrollView/ScrollView.js#L478) , `scrollToPosition` can do the job
