### PR TITLE
Fix lint warnings - use jsx-quotes instread of react/jsx-quotes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -181,9 +181,10 @@
     "no-bitwise": 1,
     "no-plusplus": 0,
 
+    "jsx-quotes": [1, "prefer-single"],
+
     "react/display-name": 0,
     "react/jsx-boolean-value": 0,
-    "react/jsx-quotes": [1, "single", "avoid-escape"],
     "react/jsx-no-undef": 1,
     "react/jsx-sort-props": 0,
     "react/jsx-uses-react": 0,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",
-    "eslint": "^2.12.0",
-    "eslint-plugin-react": "^5.1.1"
+    "eslint": "^3.17.1",
+    "eslint-plugin-react": "^6.10.0"
   }
 }


### PR DESCRIPTION
This removes the ESLint warning `warning  Definition for rule 'react/jsx-quotes' was not found  react/jsx-quotes`.

#### Actual warnings
```
/Users/gaishimo/src/sandbox/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareListView.js
  3:1  warning  Definition for rule 'react/jsx-quotes' was not found  react/jsx-quotes

/Users/gaishimo/src/sandbox/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareMixin.js
  3:1  warning  Definition for rule 'react/jsx-quotes' was not found  react/jsx-quotes

/Users/gaishimo/src/sandbox/react-native-keyboard-aware-scroll-view/lib/KeyboardAwareScrollView.js
  3:1  warning  Definition for rule 'react/jsx-quotes' was not found  react/jsx-quotes
  ```
