### PR TITLE
Safe getScrollResponder

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -59,12 +59,13 @@ const KeyboardAwareMixin = {
     // Automatically scroll to focused TextInput
     if (this.props.enableAutoAutomaticScroll) {
       const currentlyFocusedField = TextInput.State.currentlyFocusedField()
-      if (!currentlyFocusedField) {
+      const responder = this.getScrollResponder();
+      if (!currentlyFocusedField || !responder) {
         return
       }
       UIManager.viewIsDescendantOf(
         currentlyFocusedField,
-        this.getScrollResponder().getInnerViewNode(),
+        responder.getInnerViewNode(),
         (isAncestor) => {
           if (isAncestor) {
             // Check if the TextInput will be hidden by the keyboard
@@ -115,15 +116,17 @@ const KeyboardAwareMixin = {
   },
 
   getScrollResponder() {
-    return this.refs._rnkasv_keyboardView.getScrollResponder()
+    return this.refs._rnkasv_keyboardView && this.refs._rnkasv_keyboardView.getScrollResponder()
   },
 
   scrollToPosition: function (x: number, y: number, animated: bool = true) {
-    this.getScrollResponder().scrollResponderScrollTo({x: x, y: y, animated: animated})
+    const responder = this.getScrollResponder();
+    responder && responder.scrollResponderScrollTo({x: x, y: y, animated: animated})
   },
 
   scrollToEnd: function (animated?: bool = true) {
-    this.getScrollResponder().scrollResponderScrollToEnd({animated: animated})
+    const responder = this.getScrollResponder();
+    responder && responder.scrollResponderScrollToEnd({animated: animated})
   },
 
   /**
@@ -134,7 +137,8 @@ const KeyboardAwareMixin = {
         extraHeight = this.props.extraHeight;
     }
     this.setTimeout(() => {
-      this.getScrollResponder().scrollResponderScrollNativeHandleToKeyboard(
+      const responder = this.getScrollResponder();
+      responder && responder.scrollResponderScrollNativeHandleToKeyboard(
         reactNode, extraHeight, true
       )
     }, _KAM_KEYBOARD_OPENING_TIME)


### PR DESCRIPTION
In our app redux can switch navigation when input is in focus. 
When this happen we get crash:

```
TypeError
undefined is not an object (evaluating 'this.refs._rnkasv_keyboardView.getScrollResponder')
```

This PR make getScrollResponder a little bit safer.