### PR TITLE
Reset Scroll Fix

### DIFF
--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -85,7 +85,7 @@ const KeyboardAwareMixin = {
   },
 
   resetKeyboardSpace: function () {
-    const keyboardSpace: number = (this.props.viewIsInsideTabBar) ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight : this.props.extraScrollHeight
+    const keyboardSpace: number = (this.props.viewIsInsideTabBar) ? _KAM_DEFAULT_TAB_BAR_HEIGHT : 0
     this.setState({keyboardSpace})
     // Reset scroll position after keyboard dismissal
     if (this.props.enableResetScrollToCoords === false) {

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -69,7 +69,7 @@ const KeyboardAwareMixin = {
           if (isAncestor) {
             // Check if the TextInput will be hidden by the keyboard
             UIManager.measureInWindow(currentlyFocusedField, (x, y, width, height) => {
-              if (y + height > frames.endCoordinates.screenY - this.props.extraScrollHeight - this.props.extraHeight) {
+              if (y + height > frames.endCoordinates.screenY - this.props.extraScrollHeight) {
                 this.scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
               }
             })


### PR DESCRIPTION
removing extraScrollHeight from the reset scroll position to prevent extra space being at the bottom of the screen after resetting the scroll.