### PR TITLE
Fix TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Kyle Roach <https://github.com/iRoachie>
 // TypeScript Version: 2.3.2
 
-import React from 'react'
+import * as React from 'react'
 import { ScrollViewProperties, ListViewProperties } from 'react-native'
 
 interface KeyboardAwareProps {


### PR DESCRIPTION
The React import was previously incorrect, causing compile failures in React Native projects that utilize TypeScript. This fixes https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/126.

Verified this change working in our project, which is built using:
* TypeScript 2.3.4
* React Native 0.43.6
* React 15.0.26