### PR TITLE
Fix state type in typescript components

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ import { ScrollViewProperties, ListViewProperties } from 'react-native'
 interface KeyboardAwareProps {
     /**
      * Adds an extra offset that represents the TabBarIOS height.
-     * 
+     *
      * @type {boolean}
      * @memberof KeyboardAwareProps
      */
@@ -17,7 +17,7 @@ interface KeyboardAwareProps {
 
     /**
      * Coordinates that will be used to reset the scroll when the keyboard hides.
-     * 
+     *
      * @type {{
      *         x: number,
      *         y: number
@@ -31,7 +31,7 @@ interface KeyboardAwareProps {
 
     /**
      * Lets the user enable or disable automatic resetScrollToCoords
-     * 
+     *
      * @type {boolean}
      * @memberof KeyboardAwareProps
      */
@@ -39,9 +39,9 @@ interface KeyboardAwareProps {
 
     /**
      * When focus in TextInput will scroll the position
-     * 
+     *
      * Default is true
-     * 
+     *
      * @type {boolean}
      * @memberof KeyboardAwareProps
      */
@@ -57,11 +57,11 @@ interface KeyboardAwareProps {
     extraHeight?: number
 
     /**
-     * Adds an extra offset to the keyboard. 
+     * Adds an extra offset to the keyboard.
      * Useful if you want to stick elements above the keyboard.
-     * 
+     *
      * Default is 0
-     * 
+     *
      * @type {number}
      * @memberof KeyboardAwareProps
      */
@@ -71,6 +71,10 @@ interface KeyboardAwareProps {
 interface KeyboardAwareListViewProps extends KeyboardAwareProps, ListViewProperties {}
 interface KeyboardAwareScrollViewProps extends KeyboardAwareProps, ScrollViewProperties {}
 
+interface KeyboardAwareState {
+  keyboardSpace: number
+}
+
 export class KeyboardAwareMixin {}
-export class KeyboardAwareListView extends React.Component<KeyboardAwareListViewProps, any> { }
-export class KeyboardAwareScrollView extends React.Component<KeyboardAwareScrollViewProps, any> { }
+export class KeyboardAwareListView extends React.Component<KeyboardAwareListViewProps, KeyboardAwareState> { }
+export class KeyboardAwareScrollView extends React.Component<KeyboardAwareScrollViewProps, KeyboardAwareState> { }

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,5 +72,5 @@ interface KeyboardAwareListViewProps extends KeyboardAwareProps, ListViewPropert
 interface KeyboardAwareScrollViewProps extends KeyboardAwareProps, ScrollViewProperties {}
 
 export class KeyboardAwareMixin {}
-export class KeyboardAwareListView extends React.Component<KeyboardAwareListViewProps, null> { }
-export class KeyboardAwareScrollView extends React.Component<KeyboardAwareScrollViewProps, null> { }
+export class KeyboardAwareListView extends React.Component<KeyboardAwareListViewProps, any> { }
+export class KeyboardAwareScrollView extends React.Component<KeyboardAwareScrollViewProps, any> { }


### PR DESCRIPTION
When used in typescript project, current version of KeyboardAwareScrollView from master branch fails to compile with following warning:
```
src/components/Screen.tsx(43,5): error TS2605: JSX element type 'KeyboardAwareScrollView' is not a constructor function for JSX elements.
  Types of property 'setState' are incompatible.
    Type '{ <K extends never>(f: (prevState: null, props: KeyboardAwareScrollViewProps) => Pick<null, K>, c...' is not assignable to type '{ <K extends never>(f: (prevState: {}, props: any) => Pick<{}, K>, callback?: (() => any) | undef...'.
      Types of parameters 'f' and 'f' are incompatible.
        Type '(prevState: {}, props: any) => Pick<{}, any>' is not assignable to type '(prevState: null, props: KeyboardAwareScrollViewProps) => Pick<null, any>'.
          Types of parameters 'prevState' and 'prevState' are incompatible.
            Type 'null' is not assignable to type '{}'.

```
I am using typescript 2.3.4
This PR fixes this by setting state type to any. I think this is correct because KeyboardAwareScrollView internally has state.