### PR TITLE
Change value of scrollEventThrottle to 1

### DIFF
--- a/lib/KeyboardAwareFlatList.js
+++ b/lib/KeyboardAwareFlatList.js
@@ -54,7 +54,7 @@ const KeyboardAwareFlatList = createReactClass({
         contentInset={{bottom: keyboardSpace}}
         automaticallyAdjustContentInsets={false}
         showsVerticalScrollIndicator={true}
-        scrollEventThrottle={0}
+        scrollEventThrottle={1}
         {...this.props}
         contentContainerStyle={newContentContainerStyle || contentContainerStyle}
         onScroll={this.onScroll}

--- a/lib/KeyboardAwareListView.js
+++ b/lib/KeyboardAwareListView.js
@@ -54,7 +54,7 @@ const KeyboardAwareListView = createReactClass({
         contentInset={{bottom: keyboardSpace}}
         automaticallyAdjustContentInsets={false}
         showsVerticalScrollIndicator={true}
-        scrollEventThrottle={0}
+        scrollEventThrottle={1}
         {...this.props}
         contentContainerStyle={newContentContainerStyle || contentContainerStyle}
         onScroll={this.onScroll}

--- a/lib/KeyboardAwareScrollView.js
+++ b/lib/KeyboardAwareScrollView.js
@@ -47,7 +47,7 @@ const KeyboardAwareScrollView = createReactClass({
         contentInset={{bottom: keyboardSpace}}
         automaticallyAdjustContentInsets={false}
         showsVerticalScrollIndicator={true}
-        scrollEventThrottle={0}
+        scrollEventThrottle={1}
         {...this.props}
         contentContainerStyle={newContentContainerStyle || contentContainerStyle}
         onScroll={e => {


### PR DESCRIPTION
Change the value of scrollEventThrottle to 1, in order to fix the bug on automatic resetScrollToCoords. However, the onScroll event can only be fired 60 times per second (screen refresh rate), so there is no difference between 1 and 16 for scrollEventThrottle.