### PR TITLE
Support innerRef

### DIFF
--- a/lib/KeyboardAwareFlatList.js
+++ b/lib/KeyboardAwareFlatList.js
@@ -49,7 +49,7 @@ const KeyboardAwareFlatList = createReactClass({
 
     return (
       <FlatList
-        ref='_rnkasv_keyboardView'
+        ref={this.handleRef}
         keyboardDismissMode='interactive'
         contentInset={{bottom: keyboardSpace}}
         automaticallyAdjustContentInsets={false}

--- a/lib/KeyboardAwareListView.js
+++ b/lib/KeyboardAwareListView.js
@@ -49,7 +49,7 @@ const KeyboardAwareListView = createReactClass({
 
     return (
       <ListView
-        ref='_rnkasv_keyboardView'
+        ref={this.handleRef}
         keyboardDismissMode='interactive'
         contentInset={{bottom: keyboardSpace}}
         automaticallyAdjustContentInsets={false}

--- a/lib/KeyboardAwareMixin.js
+++ b/lib/KeyboardAwareMixin.js
@@ -141,7 +141,7 @@ const KeyboardAwareMixin = {
   },
 
   getScrollResponder() {
-    return this.refs._rnkasv_keyboardView && this.refs._rnkasv_keyboardView.getScrollResponder()
+    return this._rnkasv_keyboardView && this._rnkasv_keyboardView.getScrollResponder()
   },
 
   scrollToPosition: function (x: number, y: number, animated: boolean = true) {
@@ -199,6 +199,13 @@ const KeyboardAwareMixin = {
   handleOnScroll: function (e: SyntheticEvent & {nativeEvent: {contentOffset: number}}) {
     this.position = e.nativeEvent.contentOffset
   },
+
+  handleRef: function(ref) {
+    this._rnkasv_keyboardView = ref
+    if (this.props.innerRef) {
+        this.props.innerRef(this._rnkasv_keyboardView)
+    }
+},
 }
 
 export default KeyboardAwareMixin

--- a/lib/KeyboardAwareScrollView.js
+++ b/lib/KeyboardAwareScrollView.js
@@ -42,7 +42,7 @@ const KeyboardAwareScrollView = createReactClass({
 
     return (
       <ScrollView
-        ref='_rnkasv_keyboardView'
+        ref={this.handleRef}
         keyboardDismissMode='interactive'
         contentInset={{bottom: keyboardSpace}}
         automaticallyAdjustContentInsets={false}


### PR DESCRIPTION
innerRef is a common pattern in the react community for passing functional refs to wrapped components. In this case wrapped scroll views. This also upgrades the way react-native-keyboard-aware-scroll-view handles refs to the current standard while modifying as little code as possible.