### PR TITLE
Add support to subscribe to keyboard events

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -9,12 +9,33 @@ import ReactNative, {
   TextInput
 } from 'react-native'
 import { isIphoneX } from 'react-native-iphone-x-helper'
-
 import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
 
 const _KAM_DEFAULT_TAB_BAR_HEIGHT: number = isIphoneX() ? 83 : 49
 const _KAM_KEYBOARD_OPENING_TIME: number = 250
 const _KAM_EXTRA_HEIGHT: number = 75
+
+const supportedKeyboardEvents = [
+  'keyboardWillShow',
+  'keyboardDidShow',
+  'keyboardWillHide',
+  'keyboardDidHide',
+  'keyboardWillChangeFrame',
+  'keyboardDidChangeFrame',
+]
+const keyboardEventToCallbackName = (eventName: string) => (
+  'on' + eventName[0].toUpperCase() + eventName.substring(1)
+)
+const keyboardEventPropTypes = supportedKeyboardEvents.reduce(
+  (acc: Object, eventName: string) => (
+    { ...acc, [keyboardEventToCallbackName(eventName)]: PropTypes.func }
+  ), {}
+)
+const keyboardAwareHOCTypeEvents = supportedKeyboardEvents.reduce(
+  (acc: Object, eventName: string) => (
+    { ...acc, [keyboardEventToCallbackName(eventName)]: Function }
+  ), {}
+)
 
 export type KeyboardAwareHOCProps = {
   viewIsInsideTabBar?: boolean,
@@ -30,7 +51,8 @@ export type KeyboardAwareHOCProps = {
   onScroll?: Function,
   contentContainerStyle?: any,
   enableOnAndroid?: boolean,
-  innerRef?: Function
+  innerRef?: Function,
+  ...keyboardAwareHOCTypeEvents
 }
 export type KeyboardAwareHOCState = {
   keyboardSpace: number
@@ -65,7 +87,8 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       onScroll: PropTypes.func,
       contentContainerStyle: PropTypes.any,
       enableOnAndroid: PropTypes.bool,
-      innerRef: PropTypes.func
+      innerRef: PropTypes.func,
+      ...keyboardEventPropTypes
     }
 
     static defaultProps = {
@@ -81,6 +104,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       super(props)
       this.keyboardWillShowEvent = undefined
       this.keyboardWillHideEvent = undefined
+      this.callbacks = {}
       this.position = { x: 0, y: 0 }
       this.defaultResetScrollToCoords = null
       const keyboardSpace: number = props.viewIsInsideTabBar
@@ -111,6 +135,13 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
           this._resetKeyboardSpace
         )
       }
+
+      supportedKeyboardEvents.forEach((eventName: string) => {
+        const callbackName = keyboardEventToCallbackName(eventName)
+        if (this.props[callbackName]) {
+          this.callbacks[eventName] = Keyboard.addListener(eventName, this.props[callbackName])
+        }
+      })
     }
 
     componentWillReceiveProps(nextProps: KeyboardAwareHOCProps) {
@@ -126,6 +157,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       this.mountedComponent = false
       this.keyboardWillShowEvent && this.keyboardWillShowEvent.remove()
       this.keyboardWillHideEvent && this.keyboardWillHideEvent.remove()
+      Object.values(this.callbacks).forEach((callback: Object) => callback.remove())
     }
 
     getScrollResponder = () => {


### PR DESCRIPTION
This commit is not strictly necessary, once lib users can make their own subscribe
to `Keyboard` events. On the other hand, this helps everything related to keyboard
to be on the same place.

Also, this commit makes the lib compliant with its documentation, which state that
`onKeyboardWillShow` is a possible prop for the component.