### PR TITLE
Add keyboardOpeningTime to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,6 +66,16 @@ interface KeyboardAwareProps {
      * @memberof KeyboardAwareProps
      */
     extraScrollHeight?: number
+
+    /**
+     * Sets the delay time before scrolling to new position
+     *
+     * Default is 250
+     *
+     * @type {number}
+     * @memberof KeyboardAwareProps
+     */
+    keyboardOpeningTime?: number
 }
 
 interface KeyboardAwareListViewProps extends KeyboardAwareProps, ListViewProperties {}


### PR DESCRIPTION
Adds the `keyboardOpeningTime` prop to the typescript definitions file