### PR TITLE
Add in the enableOnAndroid flag to the typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,16 @@ interface KeyboardAwareProps {
      * @memberof KeyboardAwareProps
      */
   enableAutoAutomaticScroll?: boolean
+  
+    /**
+     * Enables keyboard aware settings for Android
+     *
+     * Default is false
+     *
+     * @type {boolean}
+     * @memberof KeyboardAwareProps
+     */
+  enableOnAndroid?: boolean
 
   /**
      * Adds an extra offset when focusing the TextInputs.


### PR DESCRIPTION
This pull request is simply to include the enableOnAndroid flag into the index.d.ts typings file. Before this PR, the enableOnAndroid flag will throw a TypeScript error if included in the props to any of the KeyboardAware components.