### PR TITLE
Add support to subscribe to keyboard events

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -9,12 +9,23 @@ import ReactNative, {
   TextInput
 } from 'react-native'
 import { isIphoneX } from 'react-native-iphone-x-helper'
-
 import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
 
 const _KAM_DEFAULT_TAB_BAR_HEIGHT: number = isIphoneX() ? 83 : 49
 const _KAM_KEYBOARD_OPENING_TIME: number = 250
 const _KAM_EXTRA_HEIGHT: number = 75
+
+const supportedKeyboardEvents = [
+  'keyboardWillShow',
+  'keyboardDidShow',
+  'keyboardWillHide',
+  'keyboardDidHide',
+  'keyboardWillChangeFrame',
+  'keyboardDidChangeFrame',
+];
+const keyboardEventToCallbackName = eventName => (
+  'on' + eventName[0].toUpperCase() + eventName.substring(1)
+);
 
 export type KeyboardAwareHOCProps = {
   viewIsInsideTabBar?: boolean,
@@ -31,6 +42,9 @@ export type KeyboardAwareHOCProps = {
   contentContainerStyle?: any,
   enableOnAndroid?: boolean,
   innerRef?: Function
+  ...supportedKeyboardEvents.reduce(
+    (acc, eventName) => ({ ...acc, [keyboardEventToCallbackName(eventName)]: PropTypes.func }), {}
+  ),
 }
 export type KeyboardAwareHOCState = {
   keyboardSpace: number
@@ -81,6 +95,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       super(props)
       this.keyboardWillShowEvent = undefined
       this.keyboardWillHideEvent = undefined
+      this.callbacks = {};
       this.position = { x: 0, y: 0 }
       this.defaultResetScrollToCoords = null
       const keyboardSpace: number = props.viewIsInsideTabBar
@@ -111,6 +126,13 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
           this._resetKeyboardSpace
         )
       }
+
+      supportedKeyboardEvents.forEach(eventName => {
+        const callbackName = keyboardEventToCallbackName(eventName);
+        if (this.props[callbackName]) {
+          this.callbacks[eventName] = Keyboard.addListener(eventName, this.props[callbackName]);
+        }
+      });
     }
 
     componentWillReceiveProps(nextProps: KeyboardAwareHOCProps) {
@@ -126,6 +148,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       this.mountedComponent = false
       this.keyboardWillShowEvent && this.keyboardWillShowEvent.remove()
       this.keyboardWillHideEvent && this.keyboardWillHideEvent.remove()
+      Object.values(this.callbacks).forEach(callback => callback.remove());
     }
 
     getScrollResponder = () => {


### PR DESCRIPTION
This commit is not strictly necessary, once lib users can make their own subscribe
to `Keyboard` events. On the other hand, this helps everything related to keyboard
to be on the same place.

Also, this commit makes the lib compliant with its documentation, which state that
`onKeyboardWillShow` is a possible prop for the component.

Updated