### PR TITLE
scrollToFocusedInput flow types reflect how the arguments are used

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -154,9 +154,9 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
      * @param extraHeight: takes an extra height in consideration.
      */
     scrollToFocusedInput = (
-      reactNode: Object,
-      extraHeight: number,
-      keyboardOpeningTime: number
+      reactNode: any,
+      extraHeight?: number,
+      keyboardOpeningTime?: number
     ) => {
       if (extraHeight === undefined) {
         extraHeight = this.props.extraHeight || 0


### PR DESCRIPTION
`extraHeight` and `keyboardOpeningTime` are both optional arguments. `reactNode` should be `any` to match the type of `scrollResponderScrollNativeHandleToKeyboard` which is `any`. `findNodeHandle` is annotated as returning a number which causes the existing check of `Object` to fail.