### PR TITLE
Reseting keyboard space to default keyboard space after keyboard dismiss

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -321,9 +321,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
     }
 
     _resetKeyboardSpace = () => {
-      const keyboardSpace: number = this.props.viewIsInsideTabBar
-        ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight || 0
-        : this.props.extraScrollHeight || 0
+      const keyboardSpace: number = this.props.viewIsInsideTabBar ? _KAM_DEFAULT_TAB_BAR_HEIGHT : 0
       this.setState({ keyboardSpace })
       // Reset scroll position after keyboard dismissal
       if (this.props.enableResetScrollToCoords === false) {


### PR DESCRIPTION
The scrollable content was taking extra space equal to extra scroll height once the keyboard was opened and closed again. The keyboardSpace should be reset after keyboard closes which was not the case earlier. The PR contains fix to the above scenario.