### PR TITLE
Added a displayName property to the listenToKeyboardEvents HOC

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -63,6 +63,10 @@ export type ScrollIntoViewOptions = ?{
   ) => ScrollPosition
 }
 
+function getDisplayName(WrappedComponent: React$Component) {
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
+}
+
 function listenToKeyboardEvents(ScrollableComponent: React$Component) {
   return class extends React.Component<
     KeyboardAwareHOCProps,
@@ -77,6 +81,8 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
     mountedComponent: boolean
     handleOnScroll: Function
     state: KeyboardAwareHOCState
+
+    static displayName = `KeyboardAware${getDisplayName(ScrollableComponent)}`
 
     static propTypes = {
       viewIsInsideTabBar: PropTypes.bool,


### PR DESCRIPTION
The `listenToKeyboardEvents` HOC had no `displayName` property. This means that when debugging or using snapshotting or shallow rendering, the keyboard aware component would appear as `<_class>`. Adding a name makes it clearer.

In this PR I've added a `displayName` property to the 'listenToKeyboardEvents' HOC. It takes the form  'KeyboardAware{Component Name}' (example: KeyboardAwareScrollView). I added a helper 'getDisplayName' function to determine the name and fall back to a generic name.