### PR TITLE
Add missing ref.props.scrollIntoView method

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -417,6 +417,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
           scrollToEnd={this.scrollToEnd}
           scrollForExtraHeightOnAndroid={this.scrollForExtraHeightOnAndroid}
           scrollToFocusedInput={this.scrollToFocusedInput}
+          scrollIntoView={this.scrollIntoView}
           resetKeyboardSpace={this._resetKeyboardSpace}
           handleOnScroll={this._handleOnScroll}
           onScroll={this._onScroll}


### PR DESCRIPTION
The imperative method is not exposed currently