### PR TITLE
scrollIntoView: improve _defaultGetScrollPosition

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -239,10 +239,30 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       childLayout: ElementLayout,
       contentOffset: ContentOffset
     ): ScrollPosition => {
-      return {
-        x: 0,
-        y: Math.max(0, childLayout.y - parentLayout.y + contentOffset.y),
-        animated: true,
+      const scrollY = contentOffset.y;
+      const scrollViewHeight = parentLayout.height;
+      const childHeight = childLayout.height;
+      // Measures are for window, so we make them relative to ScrollView instead
+      const childTopY = childLayout.y - parentLayout.y;
+      const childBottomY = childTopY + childHeight;
+      const createReturn = y => {
+        return {
+          x: 0,
+          y: y,
+          animated: true,
+        };
+      };
+      // ChildView top is above ScrollView: align child top to scrollview top
+      if ( childTopY < 0 ) {
+        return createReturn(scrollY + childTopY);
+      }
+      // ChildView bottom is under ScrollView: align child bottom to scroll
+      else if ( childBottomY > scrollViewHeight ) {
+        return createReturn(scrollY + childBottomY - scrollViewHeight);
+      }
+      // In other cases, let scroll position unchanged
+      else {
+        return createReturn(scrollY);
       }
     }
 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -239,30 +239,30 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       childLayout: ElementLayout,
       contentOffset: ContentOffset
     ): ScrollPosition => {
-      const scrollY = contentOffset.y;
-      const scrollViewHeight = parentLayout.height;
-      const childHeight = childLayout.height;
+      const scrollY = contentOffset.y
+      const scrollViewHeight = parentLayout.height
+      const childHeight = childLayout.height
       // Measures are for window, so we make them relative to ScrollView instead
-      const childTopY = childLayout.y - parentLayout.y;
-      const childBottomY = childTopY + childHeight;
-      const createReturn = y => {
+      const childTopY = childLayout.y - parentLayout.y
+      const childBottomY = childTopY + childHeight
+      const createReturn = y: number => {
         return {
           x: 0,
           y: y,
           animated: true,
-        };
-      };
+        }
+      }
       // ChildView top is above ScrollView: align child top to scrollview top
       if ( childTopY < 0 ) {
-        return createReturn(scrollY + childTopY);
+        return createReturn(scrollY + childTopY)
       }
       // ChildView bottom is under ScrollView: align child bottom to scroll
       else if ( childBottomY > scrollViewHeight ) {
-        return createReturn(scrollY + childBottomY - scrollViewHeight);
+        return createReturn(scrollY + childBottomY - scrollViewHeight)
       }
       // In other cases, let scroll position unchanged
       else {
-        return createReturn(scrollY);
+        return createReturn(scrollY)
       }
     }
 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -245,7 +245,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       // Measures are for window, so we make them relative to ScrollView instead
       const childTopY = childLayout.y - parentLayout.y
       const childBottomY = childTopY + childHeight
-      const createReturn = y: number => {
+      const createReturn = (y: number) => {
         return {
           x: 0,
           y: y,


### PR DESCRIPTION
Currently the default implementation always align childview top to scrollview top, which may not always be a good idea, particularly if element is already fully visible into the view.

This implementation is closer to the expected behavior and closer to DOM `element.scrollIntoView()`

See also https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/216#issuecomment-393079601