### PR TITLE
Support Animated.ScrollView with Animated.event()

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -7,7 +7,8 @@ import ReactNative, {
   Platform,
   UIManager,
   TextInput,
-  findNodeHandle
+  findNodeHandle,
+  Animated
 } from 'react-native'
 import { isIphoneX } from 'react-native-iphone-x-helper'
 
@@ -81,7 +82,6 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
     mountedComponent: boolean
     handleOnScroll: Function
     state: KeyboardAwareHOCState
-
     static displayName = `KeyboardAware${getDisplayName(ScrollableComponent)}`
 
     static propTypes = {
@@ -382,15 +382,8 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
       }
     }
 
-    _onScroll = (
-      e: SyntheticEvent<*> & { nativeEvent: { contentOffset: number } }
-    ) => {
-      this._handleOnScroll(e)
-      this.props.onScroll && this.props.onScroll(e)
-    }
-
     render() {
-      const { enableOnAndroid, contentContainerStyle } = this.props
+      const { enableOnAndroid, contentContainerStyle, onScroll } = this.props
       let newContentContainerStyle
       if (Platform.OS === 'android' && enableOnAndroid) {
         newContentContainerStyle = [].concat(contentContainerStyle).concat({
@@ -419,7 +412,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
           scrollToFocusedInput={this.scrollToFocusedInput}
           resetKeyboardSpace={this._resetKeyboardSpace}
           handleOnScroll={this._handleOnScroll}
-          onScroll={this._onScroll}
+          onScroll={Animated.forkEvent(onScroll,this._handleOnScroll)}
         />
       )
     }


### PR DESCRIPTION
Hi,

Current implementation does not support passing a onScroll listener using `Animated.event()` listener, which is particularly useful when you want to implement a ScrollView with native driver parallax effects or things like that.

I just discovered there's this "Animated.forkEvent" method which permit to add a listener to the existing user onScroll callback. It works with both original function and Animated.event(): https://github.com/facebook/react-native/blob/c6b96c0df789717d53ec520ad28ba0ae00db6ec2/Libraries/Animated/src/AnimatedImplementation.js#L477