### PR TITLE
Ability to provide custom ScrollableComponent ref prop (ie innerRef)

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -127,6 +127,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
     }
 
     static defaultProps = {
+      refPropName: 'ref',
       enableAutomaticScroll: true,
       extraHeight: _KAM_EXTRA_HEIGHT,
       extraScrollHeight: 0,
@@ -430,7 +431,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
     }
 
     render() {
-      const { enableOnAndroid, contentContainerStyle, onScroll } = this.props
+      const { enableOnAndroid, refPropName, contentContainerStyle, onScroll } = this.props
       let newContentContainerStyle
       if (Platform.OS === 'android' && enableOnAndroid) {
         newContentContainerStyle = [].concat(contentContainerStyle).concat({
@@ -439,9 +440,10 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
             this.state.keyboardSpace
         })
       }
+      const refProps = { [refPropName]: this._handleRef };
       return (
         <ScrollableComponent
-          ref={this._handleRef}
+          {...refProps}
           keyboardDismissMode='interactive'
           contentInset={{ bottom: this.state.keyboardSpace }}
           automaticallyAdjustContentInsets={false}

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -440,7 +440,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
             this.state.keyboardSpace
         })
       }
-      const refProps = { [refPropName]: this._handleRef };
+      const refProps = { [refPropName]: this._handleRef }
       return (
         <ScrollableComponent
           {...refProps}


### PR DESCRIPTION
This permits to integrate more easily with other existing ScrollView wrappers/HOC's

To give more insight on my usecase, here's real code of my app (that will work once this PR is merged).
Note that I use glamorous ScrollView on purpose so in any case I need to pass it `innerRef` prop, not ref.

```js
import React from 'react';
import { listenToKeyboardEvents } from 'react-native-keyboard-aware-scroll-view';
import { View, ScrollView } from 'glamorous-native';
import { ScrollIntoViewWrapper } from 'react-native-scroll-into-view';
import { AnimatedScrollView } from 'common/components/utils/GlamorousUtils';
import { compose } from 'recompose';

const makeKeyboardAware = Comp => {
  const debugOnAndroid = __DEV__ && true;
  const Wrapped = listenToKeyboardEvents(Comp);
  // Need to provide keyboard-aware hoc conf by props for now :(
  // See https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/272
  Wrapped.defaultProps = {
    refPropName: 'innerRef',
    enableOnAndroid: debugOnAndroid,
  };
  return Wrapped;
};

// We implement a custom scrollview because:
// - we need to ensure ios inputs remain visible after keyboard apparition (works by default on android)
// - we need equivalent of "element.scrollIntoView()" DOM function for some cases of the app
const CustomScrollView = compose(
  makeKeyboardAware,
  ScrollIntoViewWrapper({ refPropName: 'innerRef' }),
)(ScrollView);

export default CustomScrollView;

export const CustomScrollViewAnimated = compose(
  makeKeyboardAware,
  ScrollIntoViewWrapper({ refPropName: 'innerRef' }),
)(AnimatedScrollView);
```