### PR TITLE
_handleRef: support for Animated wrappers

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -410,7 +410,7 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
     }
 
     _handleRef = (ref: React.Component<*>) => {
-      this._rnkasv_keyboardView = ref
+      this._rnkasv_keyboardView = ref.getNode ? ref.getNode() : ref
       if (this.props.innerRef) {
         this.props.innerRef(this._rnkasv_keyboardView)
       }


### PR DESCRIPTION
Currently the ref provided by Animated.ScrollView is a wrapper, on which we can call "getNode()"

The current change ensure that we unwrap the real scrollview before trying to use the scrollview methods, and keep retrocompatibility for non-animated scrollviews

See also https://github.com/facebook/react-native/issues/19650