### PR TITLE
Fix leftover blank space at bottom of scrollView on android

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -362,8 +362,8 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
 
     _resetKeyboardSpace = () => {
       const keyboardSpace: number = this.props.viewIsInsideTabBar
-        ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight || 0
-        : this.props.extraScrollHeight || 0
+        ? _KAM_DEFAULT_TAB_BAR_HEIGHT
+        : 0
       this.setState({ keyboardSpace })
       // Reset scroll position after keyboard dismissal
       if (this.props.enableResetScrollToCoords === false) {


### PR DESCRIPTION
Recently we discovered a layout bug on Android where the temporary `extraScrollHeight` bottom-padding never went away after the keyboard was closed.

I dove into the code and noticed that when `keyboardDidHide` (Android) is triggered, `_resetKeyboardSpace` intends to reset the keyboardSpace (bottomPadding) state, but is including `extraScrollHeight` in the final calculation. That doesn't seem right, and removing it fixes our leftover padding issue after the keyboard is closed.

This change doesn't seem to cause any problems on iOS.