### PR TITLE
Apply content inset to ScrollView regardless of enableAutomaticScroll property

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -291,13 +291,13 @@ function listenToKeyboardEvents(ScrollableComponent: React$Component) {
 
     // Keyboard actions
     _updateKeyboardSpace = (frames: Object) => {
+      let keyboardSpace: number = frames.endCoordinates.height + this.props.extraScrollHeight
+      if (this.props.viewIsInsideTabBar) {
+        keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
+      }
+      this.setState({ keyboardSpace })
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
-        let keyboardSpace: number = frames.endCoordinates.height + this.props.extraScrollHeight
-        if (this.props.viewIsInsideTabBar) {
-          keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
-        }
-        this.setState({ keyboardSpace })
         const currentlyFocusedField = TextInput.State.currentlyFocusedField()
         const responder = this.getScrollResponder()
         if (!currentlyFocusedField || !responder) {


### PR DESCRIPTION
If you disable automatic scroll (say, if you want to do some custom behaviour like scrollIntoView()) the content inset that compensates for the soft keyboard is no longer applied. As a result the view is partly obstructed (i.e. no longer 'keyboard aware'), and the scroll methods like scrollIntoView don't work as expected.