### PR TITLE
Add a missing type in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,6 +8,14 @@ import { ScrollViewProperties, ListViewProperties, FlatListProperties, SectionLi
 
 interface KeyboardAwareProps {
   /**
+     * Catches the reference of the component.
+     *
+     *
+     * @type {function}
+     * @memberof KeyboardAwareProps
+     */
+  innerRef?: (ref: JSX.Element) => void
+  /**
      * Adds an extra offset that represents the TabBarIOS height.
      *
      * Default is false


### PR DESCRIPTION
This is a minor fix related to https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/285 !
Please confirm.