### PR TITLE
When enableResetScrollToCoords is not false, use this.props.resetScro…

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -152,7 +152,6 @@ function KeyboardAwareHOC(
     keyboardWillHideEvent: ?Function
     position: ContentOffset
     defaultResetScrollToCoords: ?{ x: number, y: number }
-    resetCoords: ?{ x: number, y: number }
     mountedComponent: boolean
     handleOnScroll: Function
     state: KeyboardAwareHOCState

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -420,7 +420,7 @@ function KeyboardAwareHOC(
           }
         )
       }
-      if (!this.resetCoords) {
+      if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
           this.defaultResetScrollToCoords = this.position
         }
@@ -436,8 +436,8 @@ function KeyboardAwareHOC(
       if (this.props.enableResetScrollToCoords === false) {
         this.defaultResetScrollToCoords = null
         return
-      } else if (this.resetCoords) {
-        this.scrollToPosition(this.resetCoords.x, this.resetCoords.y, true)
+      } else if (this.props.resetScrollToCoords) {
+        this.scrollToPosition(this.props.resetScrollToCoords.x, this.props.resetScrollToCoords.y, true)
       } else {
         if (this.defaultResetScrollToCoords) {
           this.scrollToPosition(


### PR DESCRIPTION
I noticed that passing the prop resetScrollToCoords didn't seem to have an effect, it kept scrolling to 0, 0 whatever I passed in.

I looked into the code and saw that the  _resetKeyboardSpace in KeyboardAwareHOC was checking for this.resetCoords if this.props.enableResetScrollToCoords was not equal to false and then falling back to defaultResetScrollToCoords if defined, otherwise it simply scrolled to 0,0.

I failed to find any place where resetCoords is set and I assume what we want to use here are the coordinates passed through the resetScrollToCoords prop.

The suggested fix in this pull request gives me the results I would expect for the following scenarios:

- enableResetScrollToCoords={false}: scrolls to 0,0.
- resetScrollToCoords={{ x: 0, y: 100 }}: scrolls to 0,100 when enableResetScrollToCoords is true or default.
- None of these props passed: scrolls to the default of 0,0 as it previously did.