### PR TITLE
Add keyboard callbacks to TypeScript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,48 @@ interface KeyboardAwareProps {
      * @memberof KeyboardAwareProps
      */
   keyboardOpeningTime?: number
+
+  /**
+     * Callback when the keyboard will show.
+     * 
+     * @param frames Information about the keyboard frame and animation.
+     */
+  onKeyboardWillShow?: (frames: Object) => void
+
+  /**
+     * Callback when the keyboard did show.
+     * 
+     * @param frames Information about the keyboard frame and animation.
+     */
+  onKeyboardDidShow?: (frames: Object) => void
+
+  /**
+     * Callback when the keyboard will hide.
+     * 
+     * @param frames Information about the keyboard frame and animation.
+     */
+  onKeyboardWillHide?: (frames: Object) => void
+
+  /**
+     * Callback when the keyboard did hide.
+     * 
+     * @param frames Information about the keyboard frame and animation.
+     */
+  onKeyboardDidHide?: (frames: Object) => void
+
+  /**
+     * Callback when the keyboard frame will change.
+     * 
+     * @param frames Information about the keyboard frame and animation.
+     */
+  onKeyboardWillChangeFrame?: (frames: Object) => void
+
+  /**
+     * Callback when the keyboard frame did change.
+     * 
+     * @param frames Information about the keyboard frame and animation.
+     */
+  onKeyboardDidChangeFrame?: (frames: Object) => void
 }
 
 interface KeyboardAwareListViewProps


### PR DESCRIPTION
PR for #306.

I've added types for the other callback methods thatI can see defined in the native code. They appear to all take the same arguments, although I couldn't confirm that for Android.
