### PR TITLE
Avoid multi-line update() app crash by checking first if the focused TextField is a descendant of the ScrollView

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -496,12 +496,12 @@ function KeyboardAwareHOC(
       UIManager.viewIsDescendantOf(
         currentlyFocusedField,
         responder.getInnerViewNode(),
-        (isAncestor) => {
+        (isAncestor: boolean) => {
           if (isAncestor) {
             this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField);
           }
         }
-      )
+      );
     }
 
     render() {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -491,7 +491,17 @@ function KeyboardAwareHOC(
         return
       }
 
-      this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
+      // Important check: the focused field
+      // is a descendant of this ScrollView
+      UIManager.viewIsDescendantOf(
+        currentlyFocusedField,
+        responder.getInnerViewNode(),
+        (isAncestor) => {
+          if (isAncestor) {
+            this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField);
+          }
+        }
+      )
     }
 
     render() {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -498,10 +498,10 @@ function KeyboardAwareHOC(
         responder.getInnerViewNode(),
         (isAncestor: boolean) => {
           if (isAncestor) {
-            this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField);
+            this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
           }
         }
-      );
+      )
     }
 
     render() {


### PR DESCRIPTION
If you have multiple KASVs and multiple text input fields across multiple containers, and wish to use the KASV update() [solution](https://github.com/APSL/react-native-keyboard-aware-scroll-view/pull/251) to resolve your multi-line scrollView issue - you may come across this particular error screen.

![screen shot 2018-11-20 at 5 02 54 pm](https://user-images.githubusercontent.com/4751237/48858359-2f059e80-ed89-11e8-9e92-b1acc13e6703.png)

We reference and summarize @alvaromb’s thorough [explanation](https://github.com/facebook/react-native/pull/7876) below, regarding checking React node descendants - specifically his discussion around checking if a focused TextInput is a descendent of a specific ScrollView.

For example, say there is a base screen that has ScrollView and multiple input fields. The user then taps on a button and navigates to another screen which also has ScrollView and input fields. Since the base screen did not unmount, both ScrollViews continue to exist and both will receive the keyboard events. This will cause your app to crash when the user taps on an input field on that second screen.

By checking first in the update() function that the focused TextInput field is a descendant of a specific ScrollView, we can avoid the ScrollView (that does not have the focused input as a descendent) attempting to scroll to the focused input and then crashing.

<img width="582" alt="screen shot 2018-11-21 at 12 38 50 pm" src="https://user-images.githubusercontent.com/4751237/48858931-b30c5600-ed8a-11e8-8d81-4a2e82160f35.png">
