### PR TITLE
Fixed extraScrollHeight bug with ScrollView

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -430,7 +430,7 @@ function KeyboardAwareHOC(
     _resetKeyboardSpace = () => {
       const keyboardSpace: number = this.props.viewIsInsideTabBar
         ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight || 0
-        : this.props.extraScrollHeight || 0
+        : 0
       this.setState({ keyboardSpace })
       // Reset scroll position after keyboard dismissal
       if (this.props.enableResetScrollToCoords === false) {
@@ -509,7 +509,7 @@ function KeyboardAwareHOC(
         <ScrollableComponent
           {...refProps}
           keyboardDismissMode='interactive'
-          contentInset={{ bottom: this.state.keyboardSpace <= 100 ? 0 :  this.state.keyboardSpace}}
+          contentInset={{ bottom: this.state.keyboardSpace }}
           automaticallyAdjustContentInsets={false}
           showsVerticalScrollIndicator={true}
           scrollEventThrottle={1}

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -104,7 +104,7 @@ export type KeyboardAwareHOCOptions = ?{
 }
 
 function getDisplayName(WrappedComponent: React$Component) {
-  return WrappedComponent && (WrappedComponent.displayName || WrappedComponent.name) || 'Component'
+  return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
 
 const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
@@ -152,6 +152,7 @@ function KeyboardAwareHOC(
     keyboardWillHideEvent: ?Function
     position: ContentOffset
     defaultResetScrollToCoords: ?{ x: number, y: number }
+    resetCoords: ?{ x: number, y: number }
     mountedComponent: boolean
     handleOnScroll: Function
     state: KeyboardAwareHOCState
@@ -419,7 +420,7 @@ function KeyboardAwareHOC(
           }
         )
       }
-      if (!this.props.resetScrollToCoords) {
+      if (!this.resetCoords) {
         if (!this.defaultResetScrollToCoords) {
           this.defaultResetScrollToCoords = this.position
         }
@@ -428,15 +429,15 @@ function KeyboardAwareHOC(
 
     _resetKeyboardSpace = () => {
       const keyboardSpace: number = this.props.viewIsInsideTabBar
-        ? _KAM_DEFAULT_TAB_BAR_HEIGHT
-        : 0
+        ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight || 0
+        : this.props.extraScrollHeight || 0
       this.setState({ keyboardSpace })
       // Reset scroll position after keyboard dismissal
       if (this.props.enableResetScrollToCoords === false) {
         this.defaultResetScrollToCoords = null
         return
-      } else if (this.props.resetScrollToCoords) {
-        this.scrollToPosition(this.props.resetScrollToCoords.x, this.props.resetScrollToCoords.y, true)
+      } else if (this.resetCoords) {
+        this.scrollToPosition(this.resetCoords.x, this.resetCoords.y, true)
       } else {
         if (this.defaultResetScrollToCoords) {
           this.scrollToPosition(
@@ -508,7 +509,7 @@ function KeyboardAwareHOC(
         <ScrollableComponent
           {...refProps}
           keyboardDismissMode='interactive'
-          contentInset={{ bottom: this.state.keyboardSpace }}
+          contentInset={{ bottom: this.state.keyboardSpace <= 100 ? 0 :  this.state.keyboardSpace}}
           automaticallyAdjustContentInsets={false}
           showsVerticalScrollIndicator={true}
           scrollEventThrottle={1}


### PR DESCRIPTION
I came across a bug on this library related with setting an extraScrollHeight on the KeyboardAwareView. This changes fix the extra margin that appears after the keyboard disappears on the ScrollView. What would happen is:

- I clicked on an input and the keyboard showed
- The View would scroll up to acomodate the extraScrollHeight I defined through props
- When I clicked outside the input, the keyboard closed
- An extra margin the same height as extraScrollHeight would appear on the View

This was caused because on _resetKeyboardSpace you were setting
`keyboardSpace: number = this.props.viewIsInsideTabBar
        ? _KAM_DEFAULT_TAB_BAR_HEIGHT + this.props.extraScrollHeight || 0
        : this.props.extraScrollHeight || 0`

which caused the `keyboardSpace` to be `extraScrollHeight` instead of 0 after the keyboard closed.

Hope this helps! 