### PR TITLE
Open a method to refresh the scroll due to caret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ node_modules
 AwesomeProject.xcodeproj
 AwesomeProjectTests
 index.ios.js
-iOS
+xcuserdata
 
 .idea/
 .vscode/

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Android Support is not perfect, here is the supported list:
 | `enableAutomaticScroll`     | Yes                 |
 | `extraHeight`               | Yes                 |
 | `extraScrollHeight`         | Yes                 |
+| `extraBottomInset`          | Yes                 |
 | `enableResetScrollToCoords` | Yes                 |
 | `keyboardOpeningTime`       | No                  |
 
@@ -144,6 +145,7 @@ All the `ScrollView`/`FlatList` props will be passed.
 | `enableAutomaticScroll`     | `boolean`                        | When focus in `TextInput` will scroll the position, default is enabled.                        |
 | `extraHeight`               | `number`                         | Adds an extra offset when focusing the `TextInput`s.                                           |
 | `extraScrollHeight`         | `number`                         | Adds an extra offset to the keyboard. Useful if you want to stick elements above the keyboard. |
+| `extraBottomInset`          | `number`                         | Adds an extra bottom inset to the scrollable content when keyboard is open.                    |
 | `enableResetScrollToCoords` | `boolean`                        | Lets the user enable or disable automatic resetScrollToCoords.                                 |
 | `keyboardOpeningTime`       | `number`                         | Sets the delay time before scrolling to new position, default is 250                           |
 | `enableOnAndroid`           | `boolean`                        | Enable Android Support                                                                         |

--- a/ios/RNKeyboardAwareScrollView.xcodeproj/project.pbxproj
+++ b/ios/RNKeyboardAwareScrollView.xcodeproj/project.pbxproj
@@ -1,0 +1,281 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		912EC8A021DE32F400163D5B /* RCTUIManager+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 912EC89F21DE32F400163D5B /* RCTUIManager+Additions.m */; };
+		912EC8A121DE333F00163D5B /* RCTUIManager+Additions.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 912EC89E21DE32F400163D5B /* RCTUIManager+Additions.h */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		6DA7B8011F692C4C00FD1D50 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+				912EC8A121DE333F00163D5B /* RCTUIManager+Additions.h in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		6DA7B8031F692C4C00FD1D50 /* libRNKeyboardAwareScrollView.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNKeyboardAwareScrollView.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		912EC89E21DE32F400163D5B /* RCTUIManager+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "RCTUIManager+Additions.h"; sourceTree = "<group>"; };
+		912EC89F21DE32F400163D5B /* RCTUIManager+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "RCTUIManager+Additions.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		6DA7B8001F692C4C00FD1D50 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		6DA7B7FA1F692C4C00FD1D50 = {
+			isa = PBXGroup;
+			children = (
+				6DA7B8051F692C4C00FD1D50 /* RNKeyboardAwareScrollView */,
+				6DA7B8041F692C4C00FD1D50 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		6DA7B8041F692C4C00FD1D50 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				6DA7B8031F692C4C00FD1D50 /* libRNKeyboardAwareScrollView.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		6DA7B8051F692C4C00FD1D50 /* RNKeyboardAwareScrollView */ = {
+			isa = PBXGroup;
+			children = (
+				912EC89E21DE32F400163D5B /* RCTUIManager+Additions.h */,
+				912EC89F21DE32F400163D5B /* RCTUIManager+Additions.m */,
+			);
+			path = RNKeyboardAwareScrollView;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		6DA7B8021F692C4C00FD1D50 /* RNKeyboardAwareScrollView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DA7B80C1F692C4C00FD1D50 /* Build configuration list for PBXNativeTarget "RNKeyboardAwareScrollView" */;
+			buildPhases = (
+				6DA7B7FF1F692C4C00FD1D50 /* Sources */,
+				6DA7B8001F692C4C00FD1D50 /* Frameworks */,
+				6DA7B8011F692C4C00FD1D50 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RNKeyboardAwareScrollView;
+			productName = RNSafeArea;
+			productReference = 6DA7B8031F692C4C00FD1D50 /* libRNKeyboardAwareScrollView.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		6DA7B7FB1F692C4C00FD1D50 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+				ORGANIZATIONNAME = "Masayuki Iwai";
+				TargetAttributes = {
+					6DA7B8021F692C4C00FD1D50 = {
+						CreatedOnToolsVersion = 9.0;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 6DA7B7FE1F692C4C00FD1D50 /* Build configuration list for PBXProject "RNKeyboardAwareScrollView" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 6DA7B7FA1F692C4C00FD1D50;
+			productRefGroup = 6DA7B8041F692C4C00FD1D50 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				6DA7B8021F692C4C00FD1D50 /* RNKeyboardAwareScrollView */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		6DA7B7FF1F692C4C00FD1D50 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				912EC8A021DE32F400163D5B /* RCTUIManager+Additions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		6DA7B80A1F692C4C00FD1D50 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		6DA7B80B1F692C4C00FD1D50 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		6DA7B80D1F692C4C00FD1D50 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		6DA7B80E1F692C4C00FD1D50 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		6DA7B7FE1F692C4C00FD1D50 /* Build configuration list for PBXProject "RNKeyboardAwareScrollView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DA7B80A1F692C4C00FD1D50 /* Debug */,
+				6DA7B80B1F692C4C00FD1D50 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6DA7B80C1F692C4C00FD1D50 /* Build configuration list for PBXNativeTarget "RNKeyboardAwareScrollView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6DA7B80D1F692C4C00FD1D50 /* Debug */,
+				6DA7B80E1F692C4C00FD1D50 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 6DA7B7FB1F692C4C00FD1D50 /* Project object */;
+}

--- a/ios/RNKeyboardAwareScrollView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/RNKeyboardAwareScrollView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios/RNKeyboardAwareScrollView/RCTUIManager+Additions.h
+++ b/ios/RNKeyboardAwareScrollView/RCTUIManager+Additions.h
@@ -1,0 +1,9 @@
+#import <React/RCTUIManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTUIManager (Additions)
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/RNKeyboardAwareScrollView/RCTUIManager+Additions.m
+++ b/ios/RNKeyboardAwareScrollView/RCTUIManager+Additions.m
@@ -1,0 +1,45 @@
+#import "RCTUIManager+Additions.h"
+#import <UIKit/UIKit.h>
+
+@implementation RCTUIManager (Additions)
+
+RCT_EXPORT_METHOD(measureSelectionInWindow:(nonnull NSNumber *)reactTag callback:(RCTResponseSenderBlock)callback)
+{
+    [self addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        UIView *newResponder = [uiManager viewForReactTag:reactTag];
+        if ( !newResponder ) {
+            RCTLogWarn(@"measureSelectionInWindow cannot find view with tag #%@", reactTag);
+            callback(@[@"View doesn't exist"]);
+            return;
+        }
+        CGRect windowFrame = [newResponder.window convertRect:newResponder.frame fromView:newResponder.superview];
+        if ( [newResponder conformsToProtocol:@protocol(UITextInput)] ) {
+            id<UITextInput> textInput = (id<UITextInput>)newResponder;
+            UITextPosition *endPosition = textInput.selectedTextRange.end;
+            if ( endPosition ) {
+                CGRect selectionEndRect = [textInput caretRectForPosition:endPosition];
+                CGFloat textInputBottomTextInset = 0;
+                if ( [textInput isKindOfClass:[UITextView class]] ) {
+                    textInputBottomTextInset = ((UITextView *)textInput).textContainerInset.bottom;
+                }
+                callback(@[[NSNull null],
+                           @(windowFrame.origin.x),  //text input x
+                           @(windowFrame.origin.y),  //text input y
+                           @(windowFrame.size.width),  //text input width
+                           @(windowFrame.size.height),  //text input height
+                           @(windowFrame.origin.x + selectionEndRect.origin.x),  //caret x
+                           @(windowFrame.origin.y + selectionEndRect.origin.y),  //caret y
+                           @(selectionEndRect.origin.x),  //caret relative x
+                           @(selectionEndRect.origin.y),  //caret relative y
+                           @(selectionEndRect.size.width),  //caret width
+                           @(selectionEndRect.size.height),  //caret height
+                           @(textInputBottomTextInset)  // text input bottom text inset
+                           ]);
+                return;
+            }
+        }
+        callback(@[@"Text selection not available"]);
+    }];
+}
+
+@end

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -52,6 +52,7 @@ export type KeyboardAwareHOCProps = {
   enableAutomaticScroll?: boolean,
   extraHeight?: number,
   extraScrollHeight?: number,
+  extraBottomInset?: number,
   keyboardOpeningTime?: number,
   onScroll?: Function,
   update?: Function,
@@ -96,6 +97,7 @@ export type KeyboardAwareHOCOptions = ?{
   enableAutomaticScroll: boolean,
   extraHeight: number,
   extraScrollHeight: number,
+  extraBottomInset: number,
   enableResetScrollToCoords: boolean,
   keyboardOpeningTime: number,
   viewIsInsideTabBar: boolean,
@@ -113,6 +115,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   enableAutomaticScroll: true,
   extraHeight: _KAM_EXTRA_HEIGHT,
   extraScrollHeight: 0,
+  extraBottomInset: 0,
   enableResetScrollToCoords: true,
   keyboardOpeningTime: _KAM_KEYBOARD_OPENING_TIME,
   viewIsInsideTabBar: false,
@@ -184,6 +187,7 @@ function KeyboardAwareHOC(
       enableAutomaticScroll: hocOptions.enableAutomaticScroll,
       extraHeight: hocOptions.extraHeight,
       extraScrollHeight: hocOptions.extraScrollHeight,
+      extraBottomInset: hocOptions.extraBottomInset,
       enableResetScrollToCoords: hocOptions.enableResetScrollToCoords,
       keyboardOpeningTime: hocOptions.keyboardOpeningTime,
       viewIsInsideTabBar: hocOptions.viewIsInsideTabBar,
@@ -359,7 +363,7 @@ function KeyboardAwareHOC(
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =
-          frames.endCoordinates.height + this.props.extraScrollHeight
+          frames.endCoordinates.height + this.props.extraBottomInset
         if (this.props.viewIsInsideTabBar) {
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -405,6 +405,13 @@ function KeyboardAwareHOC(
       }
     }
 
+    _scrollingDelayFor( fieldId: ?number ) {
+      if ( fieldId === undefined ) { //triggered by keyboard
+        return this.props.keyboardOpeningTime || 0
+      }
+      return 0; //triggered programmatically
+    } 
+
     _refreshScrollForField( fieldId: ?number ) {
       if ( !this.state ) {
         return;
@@ -415,6 +422,8 @@ function KeyboardAwareHOC(
       if (!currentlyFocusedField || !responder ) {
         return
       }
+      const scrollingDelay = this._scrollingDelayFor( fieldId );
+
       //it is ok to not have a fieldId but if we do then it should be same with currentlyFocusedField
       if ( !( fieldId && ( currentlyFocusedField == fieldId ) || !fieldId ) ) {
         return
@@ -442,10 +451,10 @@ function KeyboardAwareHOC(
                       if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
                       {
                         //Scroll till the bottom of component
-                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace);
+                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace, scrollingDelay);
                       } else {
                         //Scroll till the caret is visible
-                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY);
+                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY, scrollingDelay);
                       }
                     }
                   }
@@ -551,7 +560,7 @@ function KeyboardAwareHOC(
       return this.props.extraScrollHeight + this._totalVerticalDistanceToWindow();
     }
 
-    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number) {
+    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number, keyboardOpeningTime?: number) {
       // Check if the TextInput will be hidden by the keyboard
       const textInputBottomPosition = y + height
       const keyboardPosition = keyboardEndCoordinatesScreenY
@@ -563,7 +572,9 @@ function KeyboardAwareHOC(
           keyboardPosition - totalExtraHeight
         ) {
           this._scrollToFocusedInputWithNodeHandle(
-            currentlyFocusedField
+            currentlyFocusedField, 
+            null, 
+            keyboardOpeningTime
           )
         }
       } else {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -65,7 +65,8 @@ export type KeyboardAwareHOCProps = {
   ...keyboardAwareHOCTypeEvents
 }
 export type KeyboardAwareHOCState = {
-  keyboardSpace: number
+  keyboardSpace: number, 
+  keyboardEndCoordinatesScreenY: number,
 }
 
 export type ElementLayout = {
@@ -163,6 +164,7 @@ function KeyboardAwareHOC(
     mountedComponent: boolean
     handleOnScroll: Function
     handleOnLayout: Function
+    refreshScrollForField: Function
     state: KeyboardAwareHOCState
     parentLayout: any
     bottomDistanceToWindow: number
@@ -219,6 +221,7 @@ function KeyboardAwareHOC(
         ? _KAM_DEFAULT_TAB_BAR_HEIGHT
         : 0
       this.state = { keyboardSpace }
+      this.refreshScrollForField = this._refreshScrollForField.bind( this );
     }
 
     async componentDidMount() {
@@ -392,47 +395,8 @@ function KeyboardAwareHOC(
         if (this.props.viewIsInsideTabBar) {
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
-        this.setState({ keyboardSpace })
-        const currentlyFocusedField = TextInput.State.currentlyFocusedField()
-        const responder = this.getScrollResponder()
-        if (!currentlyFocusedField || !responder) {
-          return
-        }
-        UIManager.viewIsDescendantOf(
-          currentlyFocusedField,
-          responder.getInnerViewNode(),
-          (isAncestor: boolean) => {
-            if (isAncestor) {
-              if (Platform.OS === 'android') {
-                this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEvent, keyboardSpace);
-              } else {
-                UIManager.measureSelectionInWindow(
-                  currentlyFocusedField,
-                  (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
-                    caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
-                    caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
-                    if ( error ) {
-                      //Try old way
-                      this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEvent, keyboardSpace);
-                    } else {
-                      // adjust scroll offset only if caret will remain out of viewable area
-                      if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEvent) ) { 
-                        //Decide if we should scroll to the caret or to the bottom of the component
-                        if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEvent) )
-                        {
-                          //Scroll till the bottom of component
-                          this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEvent, keyboardSpace);
-                        } else {
-                          //Scroll till the caret is visible
-                          this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEvent);
-                        }
-                      }
-                    }
-                });
-              }
-            }
-          }
-        )
+        this.setState({ keyboardSpace, keyboardEndCoordinatesScreenY: keyboardEvent.endCoordinates.screenY})
+        this._refreshScrollForField()
       }
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
@@ -441,6 +405,56 @@ function KeyboardAwareHOC(
       }
     }
 
+    _refreshScrollForField( fieldId: ?number ) {
+      if ( !this.state ) {
+        return;
+      }
+      const { keyboardSpace, keyboardEndCoordinatesScreenY } = this.state;
+      const currentlyFocusedField = TextInput.State.currentlyFocusedField()
+      const responder = this.getScrollResponder()
+      if (!currentlyFocusedField || !responder ) {
+        return
+      }
+      //it is ok to not have a fieldId but if we do then it should be same with currentlyFocusedField
+      if ( !( fieldId && ( currentlyFocusedField == fieldId ) || !fieldId ) ) {
+        return
+      }
+      UIManager.viewIsDescendantOf(
+        currentlyFocusedField,
+        responder.getInnerViewNode(),
+        (isAncestor: boolean) => {
+          if (isAncestor) {
+            if (Platform.OS === 'android') {
+              this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+            } else {
+              UIManager.measureSelectionInWindow(
+                currentlyFocusedField,
+                (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
+                  caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
+                  caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
+                  if ( error ) {
+                    //Try old way
+                    this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEndCoordinatesScreenY, keyboardSpace);
+                  } else {
+                    // adjust scroll offset only if caret will remain out of viewable area
+                    if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEndCoordinatesScreenY) ) { 
+                      //Decide if we should scroll to the caret or to the bottom of the component
+                      if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEndCoordinatesScreenY) )
+                      {
+                        //Scroll till the bottom of component
+                        this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEndCoordinatesScreenY, keyboardSpace);
+                      } else {
+                        //Scroll till the caret is visible
+                        this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEndCoordinatesScreenY);
+                      }
+                    }
+                  }
+              });
+            }
+          }
+        }
+      )
+    }
     _totalVerticalDistanceToWindow() {
       return this.topDistanceToWindow + this.bottomDistanceToWindow + this.props.extraBottomInset;
     }
@@ -449,7 +463,7 @@ function KeyboardAwareHOC(
       currentlyFocusedField: number, 
       caretRelativeY: number, 
       caretHeight: number, 
-      keyboardEvent: Object, 
+      keyboardEndCoordinatesScreenY: number, 
       keyboardOpeningTime?: number) 
       {
       if ( keyboardOpeningTime === undefined ) {
@@ -462,7 +476,7 @@ function KeyboardAwareHOC(
         width: number,
         height: number) => {
 
-        let keyboardScreenY = keyboardEvent.endCoordinates.screenY;
+        let keyboardScreenY = keyboardEndCoordinatesScreenY;
         let extraScrollHeigth = caretHeight/2; //show half of the bottom line
         let scrollOffsetY = y - keyboardScreenY + caretHeight + extraScrollHeigth + caretRelativeY + this._totalVerticalDistanceToWindow();
         scrollOffsetY = Math.max(0, scrollOffsetY); //prevent negative scroll offset
@@ -494,17 +508,17 @@ function KeyboardAwareHOC(
       return ( caretY + 2*caretHeight + textInputBottomTextInset ) > ( fieldY + fieldHeight ) 
     }
 
-    _isFocusedAreaFitsInViewableArea(caretY: number, fieldY: number, fieldHeight: number, keyboardEvent: Object) {
+    _isFocusedAreaFitsInViewableArea(caretY: number, fieldY: number, fieldHeight: number, keyboardEndCoordinatesScreenY: number) {
       const distanceBetweenCaretAndBottomOfField =  fieldY + fieldHeight - caretY + this.props.extraScrollHeight;
       const viewableAreaStartY = this.topDistanceToWindow;
-      const viewableAreaEndY = keyboardEvent.endCoordinates.screenY - this.props.inputAccessoryViewHeight;
+      const viewableAreaEndY = keyboardEndCoordinatesScreenY - this.props.inputAccessoryViewHeight;
       const viewableAreaHeight = viewableAreaEndY - viewableAreaStartY;
       return viewableAreaHeight > distanceBetweenCaretAndBottomOfField;
     }
 
-    _isCaretUnderKeyboard(caretY: number, caretHeight: number, keyboardEvent: Object) {
+    _isCaretUnderKeyboard(caretY: number, caretHeight: number, keyboardEndCoordinatesScreenY) {
       const caretBottomPosition = caretY + caretHeight;
-      const keyboardPosition = keyboardEvent.endCoordinates.screenY
+      const keyboardPosition = keyboardEndCoordinatesScreenY
       return caretBottomPosition > (keyboardPosition - this.props.inputAccessoryViewHeight);
     }
 
@@ -512,23 +526,23 @@ function KeyboardAwareHOC(
       return this.topDistanceToWindow > caretY;
     }
 
-    _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEvent: Object) {
-      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEvent) || 
+    _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEndCoordinatesScreenY: number) {
+      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEndCoordinatesScreenY) || 
             this._isCaretAboveViewableArea(caretY);
     }
     
-    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEvent: Object) 
+    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEndCoordinatesScreenY: number) 
     { //is there enough place in the viewable area when keyboard is open?
-      return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEvent) && 
+      return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEndCoordinatesScreenY) && 
             //is the caret at the last line of the component?
             this._isCaretAtLastLine(caretY, caretHeight, fieldY, fieldHeight, textInputBottomTextInset); 
     }
 
-    _scrollToBottomOfComponent(currentlyFocusedField: number, keyboardEvent: Object, keyboardSpace: number) {
+    _scrollToBottomOfComponent(currentlyFocusedField: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number) {
       UIManager.measureInWindow(
         currentlyFocusedField,
         (x: number, y: number, width: number, height: number) => {
-          this._doScrollToBottomOfComponent(currentlyFocusedField, y, height, keyboardEvent, keyboardSpace);
+          this._doScrollToBottomOfComponent(currentlyFocusedField, y, height, keyboardEndCoordinatesScreenY, keyboardSpace);
         }
       );
     }
@@ -537,10 +551,10 @@ function KeyboardAwareHOC(
       return this.props.extraScrollHeight + this._totalVerticalDistanceToWindow();
     }
 
-    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEvent: Object, keyboardSpace: number) {
+    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEndCoordinatesScreenY: number, keyboardSpace: number) {
       // Check if the TextInput will be hidden by the keyboard
       const textInputBottomPosition = y + height
-      const keyboardPosition = keyboardEvent.endCoordinates.screenY
+      const keyboardPosition = keyboardEndCoordinatesScreenY
       const totalExtraHeight =
         this._extraScrollHeight() + this.props.extraHeight
       if (Platform.OS === 'ios') {
@@ -673,6 +687,7 @@ function KeyboardAwareHOC(
           keyboardSpace={this.state.keyboardSpace}
           getScrollResponder={this.getScrollResponder}
           scrollToPosition={this.scrollToPosition}
+          refreshScrollForField={this.refreshScrollForField}
           scrollToEnd={this.scrollToEnd}
           scrollForExtraHeightOnAndroid={this.scrollForExtraHeightOnAndroid}
           scrollToFocusedInput={this.scrollToFocusedInput}

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -8,7 +8,8 @@ import ReactNative, {
   UIManager,
   TextInput,
   findNodeHandle,
-  Animated
+  Animated,
+  Dimensions
 } from 'react-native'
 import { isIphoneX } from 'react-native-iphone-x-helper'
 import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
@@ -53,8 +54,10 @@ export type KeyboardAwareHOCProps = {
   extraHeight?: number,
   extraScrollHeight?: number,
   extraBottomInset?: number,
+  inputAccessoryViewHeight: number,
   keyboardOpeningTime?: number,
   onScroll?: Function,
+  onLayout?: Function,
   update?: Function,
   contentContainerStyle?: any,
   enableOnAndroid?: boolean,
@@ -98,6 +101,7 @@ export type KeyboardAwareHOCOptions = ?{
   extraHeight: number,
   extraScrollHeight: number,
   extraBottomInset: number,
+  inputAccessoryViewHeight: number,
   enableResetScrollToCoords: boolean,
   keyboardOpeningTime: number,
   viewIsInsideTabBar: boolean,
@@ -116,6 +120,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   extraHeight: _KAM_EXTRA_HEIGHT,
   extraScrollHeight: 0,
   extraBottomInset: 0,
+  inputAccessoryViewHeight: 0,
   enableResetScrollToCoords: true,
   keyboardOpeningTime: _KAM_KEYBOARD_OPENING_TIME,
   viewIsInsideTabBar: false,
@@ -157,7 +162,11 @@ function KeyboardAwareHOC(
     defaultResetScrollToCoords: ?{ x: number, y: number }
     mountedComponent: boolean
     handleOnScroll: Function
+    handleOnLayout: Function
     state: KeyboardAwareHOCState
+    parentLayout: any
+    bottomDistanceToWindow: number
+    topDistanceToWindow: number
     static displayName = `KeyboardAware${getDisplayName(ScrollableComponent)}`
 
     static propTypes = {
@@ -175,6 +184,10 @@ function KeyboardAwareHOC(
         PropTypes.func, // Normal listener
         PropTypes.object // Animated.event listener
       ]),
+      onLayout: PropTypes.oneOfType([
+        PropTypes.func, // Normal listener
+        PropTypes.object // Animated.event listener
+      ]),
       update: PropTypes.func,
       contentContainerStyle: PropTypes.any,
       enableOnAndroid: PropTypes.bool,
@@ -188,6 +201,7 @@ function KeyboardAwareHOC(
       extraHeight: hocOptions.extraHeight,
       extraScrollHeight: hocOptions.extraScrollHeight,
       extraBottomInset: hocOptions.extraBottomInset,
+      inputAccessoryViewHeight: hocOptions.inputAccessoryViewHeight,
       enableResetScrollToCoords: hocOptions.enableResetScrollToCoords,
       keyboardOpeningTime: hocOptions.keyboardOpeningTime,
       viewIsInsideTabBar: hocOptions.viewIsInsideTabBar,
@@ -207,7 +221,7 @@ function KeyboardAwareHOC(
       this.state = { keyboardSpace }
     }
 
-    componentDidMount() {
+    async componentDidMount() {
       this.mountedComponent = true
       // Keyboard events
       if (Platform.OS === 'ios') {
@@ -229,7 +243,6 @@ function KeyboardAwareHOC(
           this._resetKeyboardSpace
         )
       }
-
       supportedKeyboardEvents.forEach((eventName: string) => {
         const callbackName = keyboardEventToCallbackName(eventName)
         if (this.props[callbackName]) {
@@ -358,12 +371,24 @@ function KeyboardAwareHOC(
       })
     }
 
+    async _calculateTopBottomDistanceIfNeeded() {
+      if ( !this.parentLayout ) {
+        const parentLayout = await this._measureElement(this._rnkasv_keyboardView);
+        this.parentLayout = parentLayout;
+        const { height: fullHeight } = Dimensions.get( 'window' );
+        this.bottomDistanceToWindow = fullHeight - ( parentLayout.y + parentLayout.height );
+        this.topDistanceToWindow = parentLayout.y;
+      }
+    }
+
     // Keyboard actions
-    _updateKeyboardSpace = (frames: Object) => {
+   _updateKeyboardSpace = async (keyboardEvent: Object) => {
+      await this._calculateTopBottomDistanceIfNeeded();
+
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =
-          frames.endCoordinates.height + this.props.extraBottomInset
+        keyboardEvent.endCoordinates.height + this.props.extraBottomInset
         if (this.props.viewIsInsideTabBar) {
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
@@ -378,47 +403,33 @@ function KeyboardAwareHOC(
           responder.getInnerViewNode(),
           (isAncestor: boolean) => {
             if (isAncestor) {
-              // Check if the TextInput will be hidden by the keyboard
-              UIManager.measureInWindow(
-                currentlyFocusedField,
-                (x: number, y: number, width: number, height: number) => {
-                  const textInputBottomPosition = y + height
-                  const keyboardPosition = frames.endCoordinates.screenY
-                  const totalExtraHeight =
-                    this.props.extraScrollHeight + this.props.extraHeight
-                  if (Platform.OS === 'ios') {
-                    if (
-                      textInputBottomPosition >
-                      keyboardPosition - totalExtraHeight
-                    ) {
-                      this._scrollToFocusedInputWithNodeHandle(
-                        currentlyFocusedField
-                      )
+              if (Platform.OS === 'android') {
+                this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEvent, keyboardSpace);
+              } else {
+                UIManager.measureSelectionInWindow(
+                  currentlyFocusedField,
+                  (error: ?string, fieldX: number, fieldY: number, fieldWidth: number, fieldHeight: number, 
+                    caretX: number, caretY: number, caretRelativeX: number, caretRelativeY: number, 
+                    caretWidth: number, caretHeight: number, textInputBottomTextInset: number ) => {
+                    if ( error ) {
+                      //Try old way
+                      this._scrollToBottomOfComponent(currentlyFocusedField, keyboardEvent, keyboardSpace);
+                    } else {
+                      // adjust scroll offset only if caret will remain out of viewable area
+                      if ( this._isCaretOutOfViewableArea(caretY, caretHeight, keyboardEvent) ) { 
+                        //Decide if we should scroll to the caret or to the bottom of the component
+                        if( this._shouldScrollToBottomOfComponent(fieldY, fieldHeight, caretY, caretHeight, textInputBottomTextInset, keyboardEvent) )
+                        {
+                          //Scroll till the bottom of component
+                          this._doScrollToBottomOfComponent(currentlyFocusedField, fieldY, fieldHeight, keyboardEvent, keyboardSpace);
+                        } else {
+                          //Scroll till the caret is visible
+                          this._scrollToCaret(currentlyFocusedField, caretRelativeY, caretHeight, keyboardEvent);
+                        }
+                      }
                     }
-                  } else {
-                    // On android, the system would scroll the text input just
-                    // above the keyboard so we just neet to scroll the extra
-                    // height part
-                    if (textInputBottomPosition > keyboardPosition) {
-                      // Since the system already scrolled the whole view up
-                      // we should reduce that amount
-                      keyboardSpace =
-                        keyboardSpace -
-                        (textInputBottomPosition - keyboardPosition)
-                      this.setState({ keyboardSpace })
-                      this.scrollForExtraHeightOnAndroid(totalExtraHeight)
-                    } else if (
-                      textInputBottomPosition >
-                      keyboardPosition - totalExtraHeight
-                    ) {
-                      this.scrollForExtraHeightOnAndroid(
-                        totalExtraHeight -
-                          (keyboardPosition - textInputBottomPosition)
-                      )
-                    }
-                  }
-                }
-              )
+                });
+              }
             }
           }
         )
@@ -426,6 +437,141 @@ function KeyboardAwareHOC(
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
           this.defaultResetScrollToCoords = this.position
+        }
+      }
+    }
+
+    _totalVerticalDistanceToWindow() {
+      return this.topDistanceToWindow + this.bottomDistanceToWindow + this.props.extraBottomInset;
+    }
+
+    _scrollToCaret( 
+      currentlyFocusedField: number, 
+      caretRelativeY: number, 
+      caretHeight: number, 
+      keyboardEvent: Object, 
+      keyboardOpeningTime?: number) 
+      {
+      if ( keyboardOpeningTime === undefined ) {
+        keyboardOpeningTime = this.props.keyboardOpeningTime || 0
+      }
+
+      const measureLayoutSuccessHandler = (
+        x: number,
+        y: number,
+        width: number,
+        height: number) => {
+
+        let keyboardScreenY = keyboardEvent.endCoordinates.screenY;
+        let extraScrollHeigth = caretHeight/2; //show half of the bottom line
+        let scrollOffsetY = y - keyboardScreenY + caretHeight + extraScrollHeigth + caretRelativeY + this._totalVerticalDistanceToWindow();
+        scrollOffsetY = Math.max(0, scrollOffsetY); //prevent negative scroll offset
+        const responder = this.getScrollResponder();
+        responder && 
+          responder.scrollResponderScrollTo( { x: 0, y: scrollOffsetY, animated: true } );
+      }
+      
+      const measureLayoutErrorHandler = ( e: Object ) => {
+        console.error('Error measuring text field: ', e);
+      }
+  
+      setTimeout( () => {
+          if ( !this.mountedComponent ) {
+            return
+          }
+          const responder = this.getScrollResponder();
+          responder &&
+          UIManager.measureLayout(
+            ReactNative.findNodeHandle(currentlyFocusedField),
+            ReactNative.findNodeHandle(responder.getInnerViewNode()),
+            measureLayoutErrorHandler,
+            measureLayoutSuccessHandler,
+          );
+      }, keyboardOpeningTime);
+    }
+
+    _isCaretAtLastLine(caretY: number, caretHeight: number, fieldY: number, fieldHeight: number, textInputBottomTextInset: number) {
+      return ( caretY + 2*caretHeight + textInputBottomTextInset ) > ( fieldY + fieldHeight ) 
+    }
+
+    _isFocusedAreaFitsInViewableArea(caretY: number, fieldY: number, fieldHeight: number, keyboardEvent: Object) {
+      const distanceBetweenCaretAndBottomOfField =  fieldY + fieldHeight - caretY + this.props.extraScrollHeight;
+      const viewableAreaStartY = this.topDistanceToWindow;
+      const viewableAreaEndY = keyboardEvent.endCoordinates.screenY - this.props.inputAccessoryViewHeight;
+      const viewableAreaHeight = viewableAreaEndY - viewableAreaStartY;
+      return viewableAreaHeight > distanceBetweenCaretAndBottomOfField;
+    }
+
+    _isCaretUnderKeyboard(caretY: number, caretHeight: number, keyboardEvent: Object) {
+      const caretBottomPosition = caretY + caretHeight;
+      const keyboardPosition = keyboardEvent.endCoordinates.screenY
+      return caretBottomPosition > (keyboardPosition - this.props.inputAccessoryViewHeight);
+    }
+
+    _isCaretAboveViewableArea(caretY: number) { //caret may remain above the viewable area when orientation changes
+      return this.topDistanceToWindow > caretY;
+    }
+
+    _isCaretOutOfViewableArea(caretY: number, caretHeight: number, keyboardEvent: Object) {
+      return this._isCaretUnderKeyboard(caretY, caretHeight, keyboardEvent) || 
+            this._isCaretAboveViewableArea(caretY);
+    }
+    
+    _shouldScrollToBottomOfComponent(fieldY: number, fieldHeight: number, caretY: number, caretHeight: number, textInputBottomTextInset: number, keyboardEvent: Object) 
+    { //is there enough place in the viewable area when keyboard is open?
+      return this._isFocusedAreaFitsInViewableArea( caretY, fieldY, fieldHeight, keyboardEvent) && 
+            //is the caret at the last line of the component?
+            this._isCaretAtLastLine(caretY, caretHeight, fieldY, fieldHeight, textInputBottomTextInset); 
+    }
+
+    _scrollToBottomOfComponent(currentlyFocusedField: number, keyboardEvent: Object, keyboardSpace: number) {
+      UIManager.measureInWindow(
+        currentlyFocusedField,
+        (x: number, y: number, width: number, height: number) => {
+          this._doScrollToBottomOfComponent(currentlyFocusedField, y, height, keyboardEvent, keyboardSpace);
+        }
+      );
+    }
+
+    _extraScrollHeight() {
+      return this.props.extraScrollHeight + this._totalVerticalDistanceToWindow();
+    }
+
+    _doScrollToBottomOfComponent(currentlyFocusedField: number, y: number, height: number, keyboardEvent: Object, keyboardSpace: number) {
+      // Check if the TextInput will be hidden by the keyboard
+      const textInputBottomPosition = y + height
+      const keyboardPosition = keyboardEvent.endCoordinates.screenY
+      const totalExtraHeight =
+        this._extraScrollHeight() + this.props.extraHeight
+      if (Platform.OS === 'ios') {
+        if (
+          textInputBottomPosition >
+          keyboardPosition - totalExtraHeight
+        ) {
+          this._scrollToFocusedInputWithNodeHandle(
+            currentlyFocusedField
+          )
+        }
+      } else {
+        // On android, the system would scroll the text input just
+        // above the keyboard so we just need to scroll the extra
+        // height part
+        if (textInputBottomPosition > keyboardPosition) {
+          // Since the system already scrolled the whole view up
+          // we should reduce that amount
+          let adjustedKeyboardSpace =
+            keyboardSpace -
+            (textInputBottomPosition - keyboardPosition)
+          this.setState({ adjustedKeyboardSpace })
+          this.scrollForExtraHeightOnAndroid(totalExtraHeight)
+        } else if (
+          textInputBottomPosition >
+          keyboardPosition - totalExtraHeight
+        ) {
+          this.scrollForExtraHeightOnAndroid(
+            totalExtraHeight -
+              (keyboardPosition - textInputBottomPosition)
+          )
         }
       }
     }
@@ -466,7 +612,7 @@ function KeyboardAwareHOC(
       const reactNode = ReactNative.findNodeHandle(nodeID)
       this.scrollToFocusedInput(
         reactNode,
-        extraHeight + this.props.extraScrollHeight,
+        extraHeight + this._extraScrollHeight(),
         keyboardOpeningTime !== undefined
           ? keyboardOpeningTime
           : this.props.keyboardOpeningTime || 0
@@ -477,6 +623,10 @@ function KeyboardAwareHOC(
       e: SyntheticEvent<*> & { nativeEvent: { contentOffset: number } }
     ) => {
       this.position = e.nativeEvent.contentOffset
+    }
+
+    _handleOnLayout = () => {
+      this.parentLayout = null;
     }
 
     _handleRef = (ref: React.Component<*>) => {
@@ -498,7 +648,7 @@ function KeyboardAwareHOC(
     }
 
     render() {
-      const { enableOnAndroid, contentContainerStyle, onScroll } = this.props
+      const { enableOnAndroid, contentContainerStyle, onScroll, onLayout } = this.props
       let newContentContainerStyle
       if (Platform.OS === 'android' && enableOnAndroid) {
         newContentContainerStyle = [].concat(contentContainerStyle).concat({
@@ -529,8 +679,10 @@ function KeyboardAwareHOC(
           scrollIntoView={this.scrollIntoView}
           resetKeyboardSpace={this._resetKeyboardSpace}
           handleOnScroll={this._handleOnScroll}
+          handleOnLayout={this._handleOnLayout}
           update={this.update}
           onScroll={Animated.forkEvent(onScroll, this._handleOnScroll)}
+          onLayout={Animated.forkEvent(onLayout, this._handleOnLayout)}
         />
       )
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A React Native ScrollView component that resizes when the keyboard appears.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "A React Native ScrollView component that resizes when the keyboard appears.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/react-native-keyboard-aware-scroll-view.podspec
+++ b/react-native-keyboard-aware-scroll-view.podspec
@@ -1,0 +1,18 @@
+require 'json'
+version = JSON.parse(File.read('package.json'))["version"]
+
+Pod::Spec.new do |s|
+
+  s.name            = "react-native-keyboard-aware-scroll-view"
+  s.version         = version
+  s.homepage        = "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view"
+  s.summary         = "React Native module to arrange scroll poisition according to keyboard on input fields."
+  s.license         = "MIT"
+  s.author          = "WordPress Mobile Gutenberg Team"
+  s.platform        = :ios, "8.0"
+  s.source          = { :git => "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git", :tag => s.version.to_s }
+  s.source_files    = "ios/RNKeyboardAwareScrollView/*.{h,m}"
+  s.preserve_paths  = "**/*.js"
+
+  s.dependency 'React'
+end

--- a/react-native-keyboard-aware-scroll-view.podspec
+++ b/react-native-keyboard-aware-scroll-view.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license         = "MIT"
   s.author          = "WordPress Mobile Gutenberg Team"
   s.platform        = :ios, "8.0"
-  s.source          = { :git => "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git", :tag => s.version.to_s }
+  s.source          = { :git => "https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git", :tag => "gb-v" + s.version.to_s }
   s.source_files    = "ios/RNKeyboardAwareScrollView/*.{h,m}"
   s.preserve_paths  = "**/*.js"
 


### PR DESCRIPTION
This PR extracts a new method to refresh the scroll position for a specific component due to the caret position. This is to fix https://github.com/wordpress-mobile/gutenberg-mobile/issues/464

**To Test**
Follow the steps on gutenberg-mobile PR