### PR TITLE
Fix remaining Flow issues

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -10,6 +10,7 @@ import ReactNative, {
   findNodeHandle,
   Animated,
 } from 'react-native'
+import typeof TextInputStateType from 'react-native/Libraries/Components/TextInput/TextInputState'
 import { isIphoneX } from 'react-native-iphone-x-helper'
 import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
 
@@ -34,6 +35,7 @@ const keyboardEventPropTypes = supportedKeyboardEvents.reduce(
   }),
   {},
 )
+const TextInputState: TextInputStateType = (TextInput: any).State
 
 export type KeyboardAwareHOCProps = {
   viewIsInsideTabBar?: boolean,
@@ -382,7 +384,7 @@ function KeyboardAwareHOC(
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
         this.setState({ keyboardSpace })
-        const currentlyFocusedField = TextInput.State.currentlyFocusedField()
+        const currentlyFocusedField = TextInputState.currentlyFocusedField()
         const responder = this.getScrollResponder()
         if (!currentlyFocusedField || !responder) {
           return
@@ -497,7 +499,7 @@ function KeyboardAwareHOC(
     }
 
     update = () => {
-      const currentlyFocusedField = TextInput.State.currentlyFocusedField()
+      const currentlyFocusedField = TextInputState.currentlyFocusedField()
       const responder = this.getScrollResponder()
       if (!currentlyFocusedField || !responder) {
         return

--- a/lib/KeyboardAwareInterface.js
+++ b/lib/KeyboardAwareInterface.js
@@ -6,7 +6,7 @@ export interface KeyboardAwareInterface {
   scrollToEnd: (animated?: boolean) => void,
   scrollForExtraHeightOnAndroid: (extraHeight: number) => void,
   scrollToFocusedInput: (
-    reactNode: Object,
+    reactNode: number,
     extraHeight: number,
     keyboardOpeningTime: number
   ) => void


### PR DESCRIPTION
The type of `State` static on `TextInput` is not exposed and I don't think that it will ever be, because it's not documented and it isn't used in React Native anywhere. They themselves use `TextInputState` import directly.
My typing is inexact, but it'll do. Or you can use `TextInputState` import directly too. What do you prefer?