### PR TITLE
fix: added default initializer for user options

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -137,7 +137,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
 
 function KeyboardAwareHOC(
   ScrollableComponent: React$Component,
-  userOptions: KeyboardAwareHOCOptions
+  userOptions: KeyboardAwareHOCOptions = {}
 ) {
   const hocOptions: KeyboardAwareHOCOptions = {
     ...ScrollIntoViewDefaultOptions,


### PR DESCRIPTION
Hey, I noticed that there are two paths for the initialization at the bottom of this file, one of which results in an `undefined` userOptions. This fails when the spread operator is applied to it, but this fixes the issue. Let me know if there's anything else you need.