### PR TITLE
Don't use legacy ReactNative default export

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import ReactNative, {
+import {
   Keyboard,
   Platform,
   UIManager,
@@ -459,7 +459,7 @@ function KeyboardAwareHOC(
       if (extraHeight === undefined) {
         extraHeight = this.props.extraHeight
       }
-      const reactNode = ReactNative.findNodeHandle(nodeID)
+      const reactNode = findNodeHandle(nodeID)
       this.scrollToFocusedInput(
         reactNode,
         extraHeight + this.props.extraScrollHeight,


### PR DESCRIPTION
[react-native-web removed support for this in 0.11](https://github.com/necolas/react-native-web/releases/tag/0.11.0).
No real need to do it as findNodeHandle is imported anyway.