### PR TITLE
fix bug on react-native-web

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import PropTypes from 'prop-types'
-import ReactNative, {
+import {
   Keyboard,
   Platform,
   UIManager,
@@ -459,7 +459,7 @@ function KeyboardAwareHOC(
       if (extraHeight === undefined) {
         extraHeight = this.props.extraHeight
       }
-      const reactNode = ReactNative.findNodeHandle(nodeID)
+      const reactNode = findNodeHandle(nodeID)
       this.scrollToFocusedInput(
         reactNode,
         extraHeight + this.props.extraScrollHeight,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A React Native ScrollView component that resizes when the keyboard appears.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
This branch is made because the react-native-web library doesn't have export default but the KeyboardAwareHoc.js file uses the import default.
I removed ReactNative from KeyboardAwareHoc.js and I increment the version.
This branch has been tested in both native and web and works perfectly.
Please accept this.

Great Regards
Hossein Mohammadi