### PR TITLE
Support inverted lists

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -506,9 +506,9 @@ function KeyboardAwareHOC(
       const refProps = { [hocOptions.refPropName]: this._handleRef }
 
       //support inverted views
-      const contentInset = this.props.inverted ? 
-      { bottom: this.state.keyboardSpace } : 
-      { top: this.state.keyboardSpace };
+      const contentInset = this.props.inverted ?
+      { bottom: this.state.keyboardSpace } :
+      { top: this.state.keyboardSpace }
 
       return (
         <ScrollableComponent

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -504,11 +504,17 @@ function KeyboardAwareHOC(
         })
       }
       const refProps = { [hocOptions.refPropName]: this._handleRef }
+
+      //support inverted views
+      const contentInset = this.props.inverted ? 
+      { bottom: this.state.keyboardSpace } : 
+      { top: this.state.keyboardSpace };
+
       return (
         <ScrollableComponent
           {...refProps}
           keyboardDismissMode='interactive'
-          contentInset={{ bottom: this.state.keyboardSpace }}
+          contentInset={contentInset}
           automaticallyAdjustContentInsets={false}
           showsVerticalScrollIndicator={true}
           scrollEventThrottle={1}


### PR DESCRIPTION
This allows for inverted lists to be supported by flipping the `contentInset` prop config from `bottom` to `top` if a prop of `inverted` is passed.

Fixes #321

