### PR TITLE
Add Typescript definitions for listenToKeyboardEvents

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -182,3 +182,36 @@ export class KeyboardAwareSectionList extends ScrollableComponent<
   KeyboardAwareSectionListProps<any>,
   KeyboardAwareState
 > {}
+
+export type KeyboardAwareOptions = {
+  enableOnAndroid?: boolean;
+  contentContainerStyle?: {};
+  enableAutomaticScroll?: boolean;
+  extraHeight?: number;
+  extraScrollHeight?: number;
+  enableResetScrollToCoords?: boolean;
+  keyboardOpeningTime?: number;
+  viewIsInsideTabBar?: boolean;
+  refPropName?: string;
+  extractNativeRef?(ref: JSX.Element): JSX.Element;
+};
+
+export function listenToKeyboardEvents<P>(
+  options: KeyboardAwareOptions
+): (
+  Comp: React.ComponentType<P>
+) => {
+  new (props: P | KeyboardAwareProps): ScrollableComponent<
+    P | KeyboardAwareProps,
+    KeyboardAwareState
+  >;
+};
+
+export function listenToKeyboardEvents<P>(
+  Comp: React.ComponentType<P>
+): {
+  new (props: P | KeyboardAwareProps): ScrollableComponent<
+    P | KeyboardAwareProps,
+    KeyboardAwareState
+  >;
+};


### PR DESCRIPTION
It's great that this package ships with TS definitions, but the function was missing from them.

It's tricky to properly type a HOC that returns a component with an API; but I found a way that works. 

One inconvenience is that with a curried HOC Typescript cannot infer the types of the props, and you would have to define them explicitly:

```ts
listenToKeyboardEvents<ScrollViewProps>(options)(ScrollView)
```