### PR TITLE
insetOnly option

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Android Support is not perfect, here is the supported list:
 | `viewIsInsideTabBar`        | Yes                 |
 | `resetScrollToCoords`       | Yes                 |
 | `enableAutomaticScroll`     | Yes                 |
-| `enableContentInset`        | Yes                 |
+| `insetOnly`                 | Yes                 |
 | `extraHeight`               | Yes                 |
 | `extraScrollHeight`         | Yes                 |
 | `enableResetScrollToCoords` | Yes                 |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Android Support is not perfect, here is the supported list:
 | `viewIsInsideTabBar`        | Yes                 |
 | `resetScrollToCoords`       | Yes                 |
 | `enableAutomaticScroll`     | Yes                 |
+| `enableContentInset`        | Yes                 |
 | `extraHeight`               | Yes                 |
 | `extraScrollHeight`         | Yes                 |
 | `enableResetScrollToCoords` | Yes                 |
@@ -136,17 +137,18 @@ Android Support is not perfect, here is the supported list:
 
 All the `ScrollView`/`FlatList` props will be passed.
 
-| **Prop**                    | **Type**                         | **Description**                                                                                |
-| --------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `innerRef`                  | `Function`                       | Catch the reference of the component.                                                          |
-| `viewIsInsideTabBar`        | `boolean`                        | Adds an extra offset that represents the `TabBarIOS` height.                                   |
-| `resetScrollToCoords`       | `Object: {x: number, y: number}` | Coordinates that will be used to reset the scroll when the keyboard hides.                     |
-| `enableAutomaticScroll`     | `boolean`                        | When focus in `TextInput` will scroll the position, default is enabled.                        |
-| `extraHeight`               | `number`                         | Adds an extra offset when focusing the `TextInput`s.                                           |
-| `extraScrollHeight`         | `number`                         | Adds an extra offset to the keyboard. Useful if you want to stick elements above the keyboard. |
-| `enableResetScrollToCoords` | `boolean`                        | Lets the user enable or disable automatic resetScrollToCoords.                                 |
-| `keyboardOpeningTime`       | `number`                         | Sets the delay time before scrolling to new position, default is 250                           |
-| `enableOnAndroid`           | `boolean`                        | Enable Android Support                                                                         |
+| **Prop**                    | **Type**                         | **Description**                                                                                                                                                   |
+| --------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `innerRef`                  | `Function`                       | Catch the reference of the component.                                                                                                                             |
+| `viewIsInsideTabBar`        | `boolean`                        | Adds an extra offset that represents the `TabBarIOS` height.                                                                                                      |
+| `resetScrollToCoords`       | `Object: {x: number, y: number}` | Coordinates that will be used to reset the scroll when the keyboard hides.                                                                                        |
+| `enableAutomaticScroll`     | `boolean`                        | When focus in `TextInput` will scroll the position, default is enabled.                                                                                           |
+| `insetOnly`                 | `boolean`                        | Only adds content inset for the keyboard and disables autoScroll. iOS will fit TextInput to the screen if it was visible before keyboard open. Default is false.  |
+| `extraHeight`               | `number`                         | Adds an extra offset when focusing the `TextInput`s.                                                                                                              |
+| `extraScrollHeight`         | `number`                         | Adds an extra offset to the keyboard. Useful if you want to stick elements above the keyboard.                                                                    |
+| `enableResetScrollToCoords` | `boolean`                        | Lets the user enable or disable automatic resetScrollToCoords.                                                                                                    |
+| `keyboardOpeningTime`       | `number`                         | Sets the delay time before scrolling to new position, default is 250                                                                                              |
+| `enableOnAndroid`           | `boolean`                        | Enable Android Support                                                                                                                                            |
 
 ### Methods
 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -373,9 +373,9 @@ function KeyboardAwareHOC(
       }
 
       // Only content inset for keyboard box
-      if(this.props.insetOnly) {
+      if (this.props.insetOnly) {
         this.setState({keyboardSpace})
-        return;
+        return
       }
 
       // Automatically scroll to focused TextInput

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -50,7 +50,7 @@ export type KeyboardAwareHOCProps = {
   },
   enableResetScrollToCoords?: boolean,
   enableAutomaticScroll?: boolean,
-  enableContentInset?: boolean,
+  insetOnly?: boolean,
   extraHeight?: number,
   extraScrollHeight?: number,
   keyboardOpeningTime?: number,
@@ -95,7 +95,7 @@ export type KeyboardAwareHOCOptions = ?{
   enableOnAndroid: boolean,
   contentContainerStyle: ?Object,
   enableAutomaticScroll: boolean,
-  enableContentInset: boolean,
+  insetOnly: boolean,
   extraHeight: number,
   extraScrollHeight: number,
   enableResetScrollToCoords: boolean,
@@ -117,7 +117,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   enableOnAndroid: false,
   contentContainerStyle: undefined,
   enableAutomaticScroll: true,
-  enableContentInset: false,
+  insetOnly: false,
   extraHeight: _KAM_EXTRA_HEIGHT,
   extraScrollHeight: 0,
   enableResetScrollToCoords: true,
@@ -172,7 +172,7 @@ function KeyboardAwareHOC(
       }),
       enableResetScrollToCoords: PropTypes.bool,
       enableAutomaticScroll: PropTypes.bool,
-      enableContentInset: PropTypes.bool,
+      insetOnly: PropTypes.bool,
       extraHeight: PropTypes.number,
       extraScrollHeight: PropTypes.number,
       keyboardOpeningTime: PropTypes.number,
@@ -190,7 +190,7 @@ function KeyboardAwareHOC(
     // HOC options are used to init default props, so that these options can be overriden with component props
     static defaultProps = {
       enableAutomaticScroll: hocOptions.enableAutomaticScroll,
-      enableContentInset: hocOptions.enableContentInset,
+      insetOnly: hocOptions.insetOnly,
       extraHeight: hocOptions.extraHeight,
       extraScrollHeight: hocOptions.extraScrollHeight,
       enableResetScrollToCoords: hocOptions.enableResetScrollToCoords,
@@ -372,9 +372,10 @@ function KeyboardAwareHOC(
         keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
       }
 
-      // Content inset for keyboard box
-      if(this.props.enableAutomaticScroll || this.props.enableContentInset) {
+      // Only content inset for keyboard box
+      if(this.props.insetOnly) {
         this.setState({keyboardSpace})
+        return;
       }
 
       // Automatically scroll to focused TextInput

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -50,6 +50,7 @@ export type KeyboardAwareHOCProps = {
   },
   enableResetScrollToCoords?: boolean,
   enableAutomaticScroll?: boolean,
+  enableContentInset?: boolean,
   extraHeight?: number,
   extraScrollHeight?: number,
   keyboardOpeningTime?: number,
@@ -94,6 +95,7 @@ export type KeyboardAwareHOCOptions = ?{
   enableOnAndroid: boolean,
   contentContainerStyle: ?Object,
   enableAutomaticScroll: boolean,
+  enableContentInset: boolean,
   extraHeight: number,
   extraScrollHeight: number,
   enableResetScrollToCoords: boolean,
@@ -115,6 +117,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   enableOnAndroid: false,
   contentContainerStyle: undefined,
   enableAutomaticScroll: true,
+  enableContentInset: false,
   extraHeight: _KAM_EXTRA_HEIGHT,
   extraScrollHeight: 0,
   enableResetScrollToCoords: true,
@@ -169,6 +172,7 @@ function KeyboardAwareHOC(
       }),
       enableResetScrollToCoords: PropTypes.bool,
       enableAutomaticScroll: PropTypes.bool,
+      enableContentInset: PropTypes.bool,
       extraHeight: PropTypes.number,
       extraScrollHeight: PropTypes.number,
       keyboardOpeningTime: PropTypes.number,
@@ -186,6 +190,7 @@ function KeyboardAwareHOC(
     // HOC options are used to init default props, so that these options can be overriden with component props
     static defaultProps = {
       enableAutomaticScroll: hocOptions.enableAutomaticScroll,
+      enableContentInset: hocOptions.enableContentInset,
       extraHeight: hocOptions.extraHeight,
       extraScrollHeight: hocOptions.extraScrollHeight,
       enableResetScrollToCoords: hocOptions.enableResetScrollToCoords,
@@ -361,14 +366,19 @@ function KeyboardAwareHOC(
 
     // Keyboard actions
     _updateKeyboardSpace = (frames: Object) => {
+      let keyboardSpace: number =
+        frames.endCoordinates.height + this.props.extraScrollHeight
+      if (this.props.viewIsInsideTabBar) {
+        keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
+      }
+
+      // Content inset for keyboard box
+      if(this.props.enableAutomaticScroll || this.props.enableContentInset) {
+        this.setState({keyboardSpace})
+      }
+
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
-        let keyboardSpace: number =
-          frames.endCoordinates.height + this.props.extraScrollHeight
-        if (this.props.viewIsInsideTabBar) {
-          keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
-        }
-        this.setState({ keyboardSpace })
         const currentlyFocusedField = TextInput.State.currentlyFocusedField()
         const responder = this.getScrollResponder()
         if (!currentlyFocusedField || !responder) {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -371,7 +371,6 @@ function KeyboardAwareHOC(
       if (this.props.viewIsInsideTabBar) {
         keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
       }
-
       this.setState({keyboardSpace})
 
       // Automatically scroll to focused TextInput

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -372,14 +372,10 @@ function KeyboardAwareHOC(
         keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
       }
 
-      // Only content inset for keyboard box
-      if (this.props.insetOnly) {
-        this.setState({keyboardSpace})
-        return
-      }
+      this.setState({keyboardSpace})
 
       // Automatically scroll to focused TextInput
-      if (this.props.enableAutomaticScroll) {
+      if (this.props.enableAutomaticScroll && !this.props.insetOnly) {
         const currentlyFocusedField = TextInput.State.currentlyFocusedField()
         const responder = this.getScrollResponder()
         if (!currentlyFocusedField || !responder) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A React Native ScrollView component that resizes when the keyboard appears.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Added insetOnly option. When enabled HOC only adds content inset if keyboard opened. Works well and useful when TexiInput initially visible on the screen. With inset iOS scrolls to it automatically and no thirdparty autoscrolling required.

This bug was a motivation to implementing it: https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/389