### PR TITLE
use UIManager.measure instead of UIManager.measureInWindow

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -380,7 +380,7 @@ function KeyboardAwareHOC(
           (isAncestor: boolean) => {
             if (isAncestor) {
               // Check if the TextInput will be hidden by the keyboard
-              UIManager.measureInWindow(
+              UIManager.measure(
                 currentlyFocusedField,
                 (x: number, y: number, width: number, height: number) => {
                   const textInputBottomPosition = y + height


### PR DESCRIPTION
When focusing inputs even slightly behind the keyboard, scroll position becomes incorrect: https://drive.google.com/file/d/1HI_aTBHg2RndH7tSKo86KBeoysULOPhG/view

By using `UIManager.measure` instead of `UIManager.measureInWindow` this issue does not occur. Not sure if this doesn't break any other use cases though