### PR TITLE
Fix issue where disabling automatic scroll would also disable all keyboard avoiding behavior.

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -362,7 +362,6 @@ function KeyboardAwareHOC(
     // Keyboard actions
     _updateKeyboardSpace = (frames: Object) => {
       // Automatically scroll to focused TextInput
-      if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =
           frames.endCoordinates.height + this.props.extraScrollHeight
         if (this.props.viewIsInsideTabBar) {
@@ -392,7 +391,7 @@ function KeyboardAwareHOC(
                       textInputBottomPosition >
                       keyboardPosition - totalExtraHeight
                     ) {
-                      this._scrollToFocusedInputWithNodeHandle(
+                      this.props.enableAutomaticScroll && this._scrollToFocusedInputWithNodeHandle(
                         currentlyFocusedField
                       )
                     }
@@ -407,12 +406,12 @@ function KeyboardAwareHOC(
                         keyboardSpace -
                         (textInputBottomPosition - keyboardPosition)
                       this.setState({ keyboardSpace })
-                      this.scrollForExtraHeightOnAndroid(totalExtraHeight)
+                      this.props.enableAutomaticScroll && this.scrollForExtraHeightOnAndroid(totalExtraHeight)
                     } else if (
                       textInputBottomPosition >
                       keyboardPosition - totalExtraHeight
                     ) {
-                      this.scrollForExtraHeightOnAndroid(
+                      this.props.enableAutomaticScroll && this.scrollForExtraHeightOnAndroid(
                         totalExtraHeight -
                           (keyboardPosition - textInputBottomPosition)
                       )
@@ -423,7 +422,7 @@ function KeyboardAwareHOC(
             }
           }
         )
-      }
+
       if (!this.props.resetScrollToCoords) {
         if (!this.defaultResetScrollToCoords) {
           this.defaultResetScrollToCoords = this.position

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -405,7 +405,7 @@ function KeyboardAwareHOC(
                       keyboardSpace =
                         keyboardSpace -
                         (textInputBottomPosition - keyboardPosition)
-                      this.setState({ keyboardSpace })
+                      // TODO: this wasn't working for castle: this.setState({ keyboardSpace })
                       this.props.enableAutomaticScroll && this.scrollForExtraHeightOnAndroid(totalExtraHeight)
                     } else if (
                       textInputBottomPosition >

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.9.1",
+  "name": "@castle-games/react-native-keyboard-aware-scroll-view",
+  "version": "0.9.2",
   "description": "A React Native ScrollView component that resizes when the keyboard appears.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Hi there!

It looks like passing `enableAutomaticScroll={false}` not only disables automatic scroll, it also prevents the component from avoiding the keyboard at all. This limits the `enableAutomaticScroll` prop to only the actual scroll behavior.