### PR TITLE
Remove deprecated getNode method 

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -100,7 +100,6 @@ export type KeyboardAwareHOCOptions = ?{
   keyboardOpeningTime: number,
   viewIsInsideTabBar: boolean,
   refPropName: string,
-  extractNativeRef: Function
 }
 
 function getDisplayName(WrappedComponent: React$Component) {
@@ -125,18 +124,6 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   // If your ScrollView is already wrapped, maybe the wrapper permit to get a ref
   // For example, with glamorous-native ScrollView, you should use "innerRef"
   refPropName: 'ref',
-  // Sometimes the ref you get is a ref to a wrapped view (ex: Animated.ScrollView)
-  // We need access to the imperative API of a real native ScrollView so we need extraction logic
-  extractNativeRef: (ref: Object) => {
-    // getNode() permit to support Animated.ScrollView automatically
-    // see https://github.com/facebook/react-native/issues/19650
-    // see https://stackoverflow.com/questions/42051368/scrollto-is-undefined-on-animated-scrollview/48786374
-    if (ref.getNode) {
-      return ref.getNode()
-    } else {
-      return ref
-    }
-  }
 }
 
 function KeyboardAwareHOC(
@@ -485,7 +472,7 @@ function KeyboardAwareHOC(
     }
 
     _handleRef = (ref: React.Component<*>) => {
-      this._rnkasv_keyboardView = ref ? hocOptions.extractNativeRef(ref) : ref
+      this._rnkasv_keyboardView = ref
       if (this.props.innerRef) {
         this.props.innerRef(this._rnkasv_keyboardView)
       }


### PR DESCRIPTION
In react native 0.62 the method getNode is deprecated, and throw a warning  when used.

https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a