### PR TITLE
Fix children not rendering issue

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -545,12 +545,15 @@ function KeyboardAwareHOC(
 // Allow to pass options, without breaking change, and curried for composition
 // listenToKeyboardEvents(ScrollView);
 // listenToKeyboardEvents(options)(Comp);
+//FIX referencing this issue
+//https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/429#issuecomment-631299411
 const listenToKeyboardEvents = (configOrComp: any) => {
-  if (typeof configOrComp === 'object') {
-    return (Comp: Function) => KeyboardAwareHOC(Comp, configOrComp)
-  } else {
-    return KeyboardAwareHOC(configOrComp)
-  }
+//   if (typeof configOrComp === 'object') {
+//     return (Comp: Function) => KeyboardAwareHOC(Comp, configOrComp)
+//   } else {
+//     return KeyboardAwareHOC(configOrComp)
+//   }
+  return KeyboardAwareHOC(configOrComp)
 }
 
 export default listenToKeyboardEvents


### PR DESCRIPTION
->Fix children not rendering anything after upgrading to RN 0.63.0
->Fix from https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/429#issuecomment-631299411