### PR TITLE
Fix #429 for broken react-native 0.63.0. Detect Forwarding Refs

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -546,7 +546,7 @@ function KeyboardAwareHOC(
 // listenToKeyboardEvents(ScrollView);
 // listenToKeyboardEvents(options)(Comp);
 const listenToKeyboardEvents = (configOrComp: any) => {
-  if (typeof configOrComp === 'object') {
+  if (typeof configOrComp === 'object' && !configOrComp.displayName) {
     return (Comp: Function) => KeyboardAwareHOC(Comp, configOrComp)
   } else {
     return KeyboardAwareHOC(configOrComp)


### PR DESCRIPTION
Fix for react native 0.63.0. They changed ScrollView to Forwarding Ref
 which caused configOrComp detection to fail https://github.com/facebook/react-native/commit/d2f314af75b63443db23e131aaf93c2d064e4f44