### PR TITLE
currentlyFocusedField => currentlyFocusedInput

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -369,19 +369,19 @@ function KeyboardAwareHOC(
           keyboardSpace -= _KAM_DEFAULT_TAB_BAR_HEIGHT
         }
         this.setState({ keyboardSpace })
-        const currentlyFocusedField = TextInput.State.currentlyFocusedField()
+        const currentlyFocusedNode = TextInput.State.currentlyFocusedInput? TextInput.State.currentlyFocusedInput() : TextInput.State.currentlyFocusedField()
         const responder = this.getScrollResponder()
-        if (!currentlyFocusedField || !responder) {
+        if (!currentlyFocusedNode || !responder) {
           return
         }
         UIManager.viewIsDescendantOf(
-          currentlyFocusedField,
+          currentlyFocusedNode,
           responder.getInnerViewNode(),
           (isAncestor: boolean) => {
             if (isAncestor) {
               // Check if the TextInput will be hidden by the keyboard
               UIManager.measureInWindow(
-                currentlyFocusedField,
+                currentlyFocusedNode,
                 (x: number, y: number, width: number, height: number) => {
                   const textInputBottomPosition = y + height
                   const keyboardPosition = frames.endCoordinates.screenY
@@ -393,7 +393,7 @@ function KeyboardAwareHOC(
                       keyboardPosition - totalExtraHeight
                     ) {
                       this._scrollToFocusedInputWithNodeHandle(
-                        currentlyFocusedField
+                        currentlyFocusedNode
                       )
                     }
                   } else {
@@ -492,14 +492,14 @@ function KeyboardAwareHOC(
     }
 
     update = () => {
-      const currentlyFocusedField = TextInput.State.currentlyFocusedField()
+      const currentlyFocusedNode = TextInput.State.currentlyFocusedInput? TextInput.State.currentlyFocusedInput() : TextInput.State.currentlyFocusedField()
       const responder = this.getScrollResponder()
 
-      if (!currentlyFocusedField || !responder) {
+      if (!currentlyFocusedNode || !responder) {
         return
       }
 
-      this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
+      this._scrollToFocusedInputWithNodeHandle(currentlyFocusedNode)
     }
 
     render() {


### PR DESCRIPTION
currentlyFocusedField is deprecated and will be removed in a future release. Use currentlyFocusedInput