### PR TITLE
Remove deprecated props from the ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ All the `ScrollView`/`FlatList` props will be passed.
 
 ### Methods
 
-Use `innerRef` to get the component reference and use `this.scrollRef.props` to access these methods.
+Use `innerRef` to get the component reference and use `this.scrollRef` to access these methods.
 
 | **Method**           | **Parameter**                                                                                                                                           | **Description**                                                |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |


### PR DESCRIPTION
It seems that there is no longer a `props` object in the `ref`, methods are now directly accessible through the`ref`