### PR TITLE
Support iPhone 12 series

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "homepage": "https://github.com/APSL/react-native-keyboard-aware-scroll-view#readme",
     "dependencies": {
         "prop-types": "^15.6.2",
-        "react-native-iphone-x-helper": "^1.0.3"
+        "react-native-iphone-x-helper": "^1.3.1"
     },
     "peerDependencies": {
         "react-native": ">=0.48.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,9 +920,10 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
-react-native-iphone-x-helper@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.0.3.tgz#7a2f1e0574e899a0f1d426e6167fd98990083214"
+react-native-iphone-x-helper@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
+  integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
 regexpp@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
react-native-iphone-x-helper started to support iPhone 12 series from v1.3.1 .

https://github.com/ptelad/react-native-iphone-x-helper/pull/29
https://github.com/ptelad/react-native-iphone-x-helper/pull/30