### PR TITLE
Upgrade Node in CI to latest LTS version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 10.4.0
+  - 14.15.1


### PR DESCRIPTION
CI is currently failing as it's using Node 10.4.0, and ESLint requires at least 10.13.0.

This PR upgrades Node to the latest LTS version, 14.15.1.