### PR TITLE
fix: auto-scroll height issue

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -303,10 +303,11 @@ function KeyboardAwareHOC(
           return
         }
         const responder = this.getScrollResponder()
+        const additionalOffset = this.state.keyboardSpace - extraHeight
         responder &&
           responder.scrollResponderScrollNativeHandleToKeyboard(
             reactNode,
-            extraHeight,
+            additionalOffset,
             true
           )
       }, keyboardOpeningTime)


### PR DESCRIPTION
## Description
- fix issue by passing contentInset's bottom number
  - change additionalOffset as (this.state.keyboardSpace - extraHeight) in function scrollResponderScrollNativeHandleToKeyboard()

## Explanation

>`additionalOffset` in `scrollResponderScrollNativeHandleToKeyboard` means scroll view's bottom "contentInset"

https://github.com/facebook/react-native/blob/4cc3aa851c181032e8ea441f0cea6459c018c1d8/Libraries/Components/ScrollView/ScrollView.js#L986
```
/**
   * This method should be used as the callback to onFocus in a TextInputs'
   * parent view. Note that any module using this mixin needs to return
   * the parent view's ref in getScrollViewRef() in order to use this method.
   * @param {number} nodeHandle The TextInput node handle
   * @param {number} additionalOffset The scroll view's bottom "contentInset".
   *        Default is 0.
   * @param {bool} preventNegativeScrolling Whether to allow pulling the content
   *        down to make it meet the keyboard's top. Default is false.
   */
  scrollResponderScrollNativeHandleToKeyboard: <T>(
    nodeHandle: number | React.ElementRef<HostComponent<T>>,
    additionalOffset?: number,
    preventNegativeScrollOffset?: boolean,
  ) => void = <T>(){}
```

>In `react-native-keyboard-aware-scroll-view`'s `KeyboardAwareHOC.js`, contentInset's bottom is `this.state.keyboardSpace`

```
<ScrollableComponent
  {...refProps}
  keyboardDismissMode='interactive'
  contentInset={{ bottom: this.state.keyboardSpace }}
```
>that's why we should pass `(this.state.keyboardSpace - extraHeight)` to `scrollResponderScrollNativeHandleToKeyboard` rather than `extraHeight`

https://github.com/APSL/react-native-keyboard-aware-scroll-view/blob/6cbf7b861856467892cef620adf9af46c4603fa8/lib/KeyboardAwareHOC.js#L307

```
const additionalOffset = this.state.keyboardSpace - extraHeight
  responder &&
    responder.scrollResponderScrollNativeHandleToKeyboard(
      reactNode,
      additionalOffset,
      true
    )
```


## Screenshots

|     | After                                                                                                       | Before                                                                                                      |
|-----|-------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| App | ![1](https://user-images.githubusercontent.com/31755924/112396521-02dcfc80-8d4c-11eb-99ae-d161f0a8fc03.gif) | ![2](https://user-images.githubusercontent.com/31755924/112396564-14be9f80-8d4c-11eb-8812-94ca809e7419.gif) |


