### PR TITLE
Fix warning due to calling getNode()

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -132,7 +132,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
     // see https://github.com/facebook/react-native/issues/19650
     // see https://stackoverflow.com/questions/42051368/scrollto-is-undefined-on-animated-scrollview/48786374
     // see https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
-    const shouldCallGetNode = !Platform.constants || (Platform.constants.reactNativeVersion.major === 0 && Platform.constants.reactNativeVersion.minor < 62);
+    const shouldCallGetNode = !Platform.constants || (Platform.constants.reactNativeVersion.major === 0 && Platform.constants.reactNativeVersion.minor < 62)
     if (ref.getNode && shouldCallGetNode) {
       return ref.getNode()
     } else {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -133,7 +133,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
     // see https://github.com/facebook/react-native/issues/19650
     // see https://stackoverflow.com/questions/42051368/scrollto-is-undefined-on-animated-scrollview/48786374
     // see https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
-    const shouldCallGetNode = !Platform.constants || Platform.constants.reactNativeVersion.major === 0 && Platform.constants.reactNativeVersion.minor < 62;
+    const shouldCallGetNode = !Platform.constants || (Platform.constants.reactNativeVersion.major === 0 && Platform.constants.reactNativeVersion.minor < 62);
     if (ref.getNode && shouldCallGetNode) {
       return ref.getNode()
     } else {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -8,8 +8,7 @@ import {
   UIManager,
   TextInput,
   findNodeHandle,
-  Animated,
-  Platform
+  Animated
 } from 'react-native'
 import { isIphoneX } from 'react-native-iphone-x-helper'
 import type { KeyboardAwareInterface } from './KeyboardAwareInterface'

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -8,7 +8,8 @@ import {
   UIManager,
   TextInput,
   findNodeHandle,
-  Animated
+  Animated,
+  Platform
 } from 'react-native'
 import { isIphoneX } from 'react-native-iphone-x-helper'
 import type { KeyboardAwareInterface } from './KeyboardAwareInterface'
@@ -128,10 +129,12 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
   // Sometimes the ref you get is a ref to a wrapped view (ex: Animated.ScrollView)
   // We need access to the imperative API of a real native ScrollView so we need extraction logic
   extractNativeRef: (ref: Object) => {
-    // getNode() permit to support Animated.ScrollView automatically
+    // getNode() permit to support Animated.ScrollView automatically, but is deprecated since RN 0.62
     // see https://github.com/facebook/react-native/issues/19650
     // see https://stackoverflow.com/questions/42051368/scrollto-is-undefined-on-animated-scrollview/48786374
-    if (ref.getNode) {
+    // see https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
+    const shouldCallGetNode = !Platform.constants || Platform.constants.reactNativeVersion.major === 0 && Platform.constants.reactNativeVersion.minor < 62;
+    if (ref.getNode && shouldCallGetNode) {
       return ref.getNode()
     } else {
       return ref


### PR DESCRIPTION
Since RN 0.62, Animated components provide the real scrollview comp as ref, not the animated wrapper, and getNode() emits a deprecation warning:

> ReactNativeFiberHostComponent: Calling `getNode()` on the ref of an Animated component is no longer necessary. You can now directly use the ref instead. This method will be removed in a future release. 

This change ensures that this lib keeps working for older RN versions, without emitting a warning for newer versions.

@alvaromb I'm going to release this immediately as I still have publish access and it should be retrocompatible, just removing an annoying warning for users on recent RN versions.

