### PR TITLE
fix scroll responder for rn v0.65 / keep backward capatability.

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -285,6 +285,7 @@ function KeyboardAwareHOC(
 
     scrollToEnd = (animated?: boolean = true) => {
       const responder = this.getScrollResponder()
+      if (!responder) return;
       if (responder.scrollResponderScrollToEnd) {
         // React Native < 0.65
         responder.scrollResponderScrollToEnd({ animated })

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -273,10 +273,10 @@ function KeyboardAwareHOC(
 
     scrollToPosition = (x: number, y: number, animated: boolean = true) => {
       const responder = this.getScrollResponder()
-      if (responder?.scrollResponderScrollTo) {
+      if (responder.scrollResponderScrollTo) {
         // React Native < 0.65
         responder.scrollResponderScrollTo({ x, y, animated })
-      } else if (responder?.scrollTo) {
+      } else if (responder.scrollTo) {
         // React Native >= 0.65
         responder.scrollTo({ x, y, animated })
       }
@@ -284,10 +284,10 @@ function KeyboardAwareHOC(
 
     scrollToEnd = (animated?: boolean = true) => {
       const responder = this.getScrollResponder()
-      if (responder?.scrollResponderScrollToEnd) {
+      if (responder.scrollResponderScrollToEnd) {
         // React Native < 0.65
         responder.scrollResponderScrollToEnd({ animated })
-      } else if (responder?.scrollToEnd) {
+      } else if (responder.scrollToEnd) {
         // React Native >= 0.65
         responder.scrollToEnd({ animated })
       }

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -286,10 +286,10 @@ function KeyboardAwareHOC(
       const responder = this.getScrollResponder()
       if (responder.scrollTo) {
         // React Native >= 0.65
-        responder.scrollTo({ x, y, animated })
+        responder.scrollToEnd({ animated })
       } else if (responder.scrollResponderScrollTo) {
         // React Native < 0.65
-        responder.scrollResponderScrollTo({ x, y, animated })
+        responder.scrollResponderEnd({ animated })
       }
     }
 

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -273,6 +273,7 @@ function KeyboardAwareHOC(
 
     scrollToPosition = (x: number, y: number, animated: boolean = true) => {
       const responder = this.getScrollResponder()
+      if (!responder) return;
       if (responder.scrollResponderScrollTo) {
         // React Native < 0.65
         responder.scrollResponderScrollTo({ x, y, animated })

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -273,12 +273,24 @@ function KeyboardAwareHOC(
 
     scrollToPosition = (x: number, y: number, animated: boolean = true) => {
       const responder = this.getScrollResponder()
-      responder && responder.scrollResponderScrollTo({ x, y, animated })
+      if (responder.scrollTo) {
+        // React Native >= 0.65
+        responder.scrollTo({ x, y, animated })
+      } else if (responder.scrollResponderScrollTo) {
+        // React Native < 0.65
+        responder.scrollResponderScrollTo({ x, y, animated })
+      }
     }
-
+    
     scrollToEnd = (animated?: boolean = true) => {
       const responder = this.getScrollResponder()
-      responder && responder.scrollResponderScrollToEnd({ animated })
+      if (responder.scrollTo) {
+        // React Native >= 0.65
+        responder.scrollTo({ x, y, animated })
+      } else if (responder.scrollResponderScrollTo) {
+        // React Native < 0.65
+        responder.scrollResponderScrollTo({ x, y, animated })
+      }
     }
 
     scrollForExtraHeightOnAndroid = (extraHeight: number) => {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -273,10 +273,10 @@ function KeyboardAwareHOC(
 
     scrollToPosition = (x: number, y: number, animated: boolean = true) => {
       const responder = this.getScrollResponder()
-      if (responder.scrollResponderScrollTo) {
+      if (responder?.scrollResponderScrollTo) {
         // React Native < 0.65
         responder.scrollResponderScrollTo({ x, y, animated })
-      } else if (responder.scrollTo) {
+      } else if (responder?.scrollTo) {
         // React Native >= 0.65
         responder.scrollTo({ x, y, animated })
       }
@@ -284,10 +284,10 @@ function KeyboardAwareHOC(
 
     scrollToEnd = (animated?: boolean = true) => {
       const responder = this.getScrollResponder()
-      if (responder.scrollResponderScrollTo) {
+      if (responder?.scrollResponderScrollToEnd) {
         // React Native < 0.65
-        responder.scrollResponderEnd({ animated })
-      } else if (responder.scrollTo) {
+        responder.scrollResponderScrollToEnd({ animated })
+      } else if (responder?.scrollToEnd) {
         // React Native >= 0.65
         responder.scrollToEnd({ animated })
       }

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -281,7 +281,7 @@ function KeyboardAwareHOC(
         responder.scrollResponderScrollTo({ x, y, animated })
       }
     }
-    
+
     scrollToEnd = (animated?: boolean = true) => {
       const responder = this.getScrollResponder()
       if (responder.scrollTo) {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -273,23 +273,23 @@ function KeyboardAwareHOC(
 
     scrollToPosition = (x: number, y: number, animated: boolean = true) => {
       const responder = this.getScrollResponder()
-      if (responder.scrollTo) {
-        // React Native >= 0.65
-        responder.scrollTo({ x, y, animated })
-      } else if (responder.scrollResponderScrollTo) {
+      if (responder.scrollResponderScrollTo) {
         // React Native < 0.65
         responder.scrollResponderScrollTo({ x, y, animated })
+      } else if (responder.scrollTo) {
+        // React Native >= 0.65
+        responder.scrollTo({ x, y, animated })
       }
     }
 
     scrollToEnd = (animated?: boolean = true) => {
       const responder = this.getScrollResponder()
-      if (responder.scrollTo) {
-        // React Native >= 0.65
-        responder.scrollToEnd({ animated })
-      } else if (responder.scrollResponderScrollTo) {
+      if (responder.scrollResponderScrollTo) {
         // React Native < 0.65
         responder.scrollResponderEnd({ animated })
+      } else if (responder.scrollTo) {
+        // React Native >= 0.65
+        responder.scrollToEnd({ animated })
       }
     }
 


### PR DESCRIPTION
As stated in [#501](https://github.com/APSL/react-native-keyboard-aware-scroll-view/pull/501#issuecomment-924891085) that fix isn't backwards compatible with previous versions of RN.

This should keep that compatibility viable while fixing the issue on the latest version of RN.

I created two apps working with different versions of RN to ensure the backwards compatibility.
You can view the code for them [here](https://github.com/CoryWritesCode/react-native-keyboard-aware-apps/tree/main)

Fixes #508
Fixes #494 