### PR TITLE
Fix crash on `shouldCallGetNode` in tests

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -132,7 +132,11 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
     // see https://github.com/facebook/react-native/issues/19650
     // see https://stackoverflow.com/questions/42051368/scrollto-is-undefined-on-animated-scrollview/48786374
     // see https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
-    const shouldCallGetNode = !Platform.constants || (Platform.constants.reactNativeVersion.major === 0 && Platform.constants.reactNativeVersion.minor < 62)
+    const shouldCallGetNode =
+      typeof Platform?.constants?.reactNativeVersion === 'Object' && 
+      Platform.constants.reactNativeVersion.major === 0 &&
+      Platform.constants.reactNativeVersion.minor < 62;
+    
     if (ref.getNode && shouldCallGetNode) {
       return ref.getNode()
     } else {

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -133,7 +133,7 @@ const ScrollIntoViewDefaultOptions: KeyboardAwareHOCOptions = {
     // see https://stackoverflow.com/questions/42051368/scrollto-is-undefined-on-animated-scrollview/48786374
     // see https://github.com/facebook/react-native/commit/66e72bb4e00aafbcb9f450ed5db261d98f99f82a
     const shouldCallGetNode =
-      typeof Platform?.constants?.reactNativeVersion === 'Object' && 
+      typeof Platform?.constants?.reactNativeVersion === 'object' && 
       Platform.constants.reactNativeVersion.major === 0 &&
       Platform.constants.reactNativeVersion.minor < 62;
     


### PR DESCRIPTION
In our test suite (jest + react-native-testing-library) `Platform.constants` is an empty object. This was making the previous `!Platform.constants` check pass, but caused a crash when trying to access `major` on `reactNativeVersion`.

This fix correctly checks if `reactNativeVersion` is present and is an object to avoid this issue.