### PR TITLE
Fix #<WeakSet> could not be cloned error with RN 0.64+

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -334,8 +334,9 @@ function KeyboardAwareHOC(
 
     scrollIntoView = async (
       element: React.Element<*>,
-      options: ScrollIntoViewOptions = {}
+      options: ScrollIntoViewOptions
     ) => {
+      options = options || {}
       if (!this._rnkasv_keyboardView || !element) {
         return
       }


### PR DESCRIPTION
Fixes https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/481
Also referenced here https://github.com/facebook/react-native/issues/31413

Babel somehow does not like async functions having params with default values. Downgrading Babel did not work for me, but removing the default param did.

Tested with RN 0.66.4.