### PR TITLE
(typescript) type scrollIntoView method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,9 @@ import * as React from 'react'
 import {
   ScrollViewProps,
   FlatListProps,
-  SectionListProps
+  SectionListProps,
+  LayoutRectangle,
+  NativeScrollPoint
 } from 'react-native'
 
 interface KeyboardAwareProps {
@@ -166,6 +168,16 @@ declare class ScrollableComponent<P, S> extends React.Component<P, S> {
     reactNode: Object,
     extraHeight?: number,
     keyboardOpeningTime?: number
+  ) => void
+  scrollIntoView: (
+    element: React.ReactElement,
+    options?: {
+      getScrollPosition?: (
+        parentLayout: LayoutRectangle,
+        childLayout: LayoutRectangle,
+        contentOffset: NativeScrollPoint
+      ) => NativeScrollPoint & { animated?: boolean }
+    }
   ) => void
 }
 


### PR DESCRIPTION
I noticed the `scrollIntoView` method of `KeyboardAwareScrollView` was not typed in Typescript. I added it, using native Typescript Types from React Native in order to ensure compatibility.

It's a slightly more complete version than #378 that should have been merged back in 2019.