### PR TITLE
Fix Keyboard Glitch on iOS by Adding Visibility Check to keyboardWillShow Event

### DIFF
--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -215,7 +215,11 @@ function KeyboardAwareHOC(
       if (Platform.OS === 'ios') {
         this.keyboardWillShowEvent = Keyboard.addListener(
           'keyboardWillShow',
-          this._updateKeyboardSpace
+          (frame) => {
+            if(Keyboard.isVisible()) { return; }
+  
+            this._updateKeyboardSpace(frame)
+          }
         )
         this.keyboardWillHideEvent = Keyboard.addListener(
           'keyboardWillHide',


### PR DESCRIPTION
This pull request addresses an issue where the keyboard glitches and causes the `keyboardWillShow` event to be triggered during certain rerendering scenarios on iOS. The fix involves adding a condition to check if the keyboard is already visible before executing the event handler logic. If the keyboard is already visible, the event handler will simply return without taking any action.

### Changes Made

Added a condition to the `keyboardWillShow` event listener to check if the keyboard is already visible.
If the keyboard is already visible, the event handler will return early, preventing unnecessary updates.


### Reason for Change
This change prevents the keyboard from glitching and showing unexpectedly during rerendering scenarios, enhancing the overall user experience and stability of the component.


### Testing
Tested on iOS to ensure the keyboard visibility check prevents unnecessary event handling during rerendering. Verified that the keyboard functionality remains intact and responsive to user interactions.